### PR TITLE
Allow `_get_all_pages` method to access private API endpoints

### DIFF
--- a/nmdc_api_utilities/data_staging.py
+++ b/nmdc_api_utilities/data_staging.py
@@ -124,9 +124,9 @@ class JGISequencingProjectAPI(NMDCSearch):
                 f"API request response: {response.json()}\n API Status Code: {response.status_code}"
             )
         if all_pages:
-            return self._get_all_pages(response, url, filter, max_page_size, fields)[
-                "resources"
-            ]
+            return self._get_all_pages(
+                response, url, filter, max_page_size, fields, self.auth.get_token()
+            )["resources"]
 
         return response.json()["resources"]
 
@@ -240,6 +240,7 @@ class JGISampleSearchAPI(NMDCSearch):
                 filter,
                 max_page_size,
                 fields,
+                self.auth.get_token(),
             )["resources"]
 
         return response.json()["resources"]
@@ -404,9 +405,9 @@ class GlobusTaskAPI(NMDCSearch):
                 f"API request response: {response.json()}\n API Status Code: {response.status_code}"
             )
         if all_pages:
-            return self._get_all_pages(response, url, filter, max_page_size, fields)[
-                "resources"
-            ]
+            return self._get_all_pages(
+                response, url, filter, max_page_size, fields, self.auth.get_token()
+            )["resources"]
         return response.json()["resources"]
 
     @requires_auth

--- a/nmdc_api_utilities/data_staging.py
+++ b/nmdc_api_utilities/data_staging.py
@@ -235,11 +235,11 @@ class JGISampleSearchAPI(NMDCSearch):
             )
         if all_pages:
             return self._get_all_pages(
-                response=response,
-                url=url,
-                filter=filter,
-                max_page_size=max_page_size,
-                fields=fields,
+                response,
+                url,
+                filter,
+                max_page_size,
+                fields,
             )["resources"]
 
         return response.json()["resources"]

--- a/nmdc_api_utilities/data_staging.py
+++ b/nmdc_api_utilities/data_staging.py
@@ -125,7 +125,12 @@ class JGISequencingProjectAPI(NMDCSearch):
             )
         if all_pages:
             return self._get_all_pages(
-                response, url, filter, max_page_size, fields, self.auth.get_token()
+                response,
+                url,
+                filter,
+                max_page_size,
+                fields,
+                access_token=self.auth.get_token(),
             )["resources"]
 
         return response.json()["resources"]

--- a/nmdc_api_utilities/nmdc_search.py
+++ b/nmdc_api_utilities/nmdc_search.py
@@ -76,14 +76,6 @@ class NMDCSearch:
             else:
                 break
 
-            # Define the query parameters for getting the next page.
-            query_params = {
-                "filter": filter,
-                "max_page_size": max_page_size,
-                "projection": fields,
-                "page_token": next_page_token,
-            }
-
             # Define the HTTP headers, which may include an access token.
             headers = {
                 "Accept": "application/json",
@@ -92,10 +84,14 @@ class NMDCSearch:
             if isinstance(access_token, str):
                 headers["Authorization"] = f"Bearer {access_token}"
 
+            # TODO: Considering using the `params` argument of `requests.get` to handle building the
+            #       URL's query string. That way, we could delegate the responsibility of encoding
+            #       query parameters, to the `requests` library.
+            #       Reference: https://requests.readthedocs.io/en/latest/user/quickstart/#passing-parameters-in-urls
+            #
+            url = f"{url_prefix}?filter={filter}&max_page_size={max_page_size}&projection={fields}&page_token={next_page_token}"
             try:
-                response = requests.get(
-                    url_prefix, headers=headers, params=query_params
-                )
+                response = requests.get(url, headers=headers)
                 response.raise_for_status()
             except requests.exceptions.RequestException as e:
                 logger.error("API request failed", exc_info=True)

--- a/nmdc_api_utilities/nmdc_search.py
+++ b/nmdc_api_utilities/nmdc_search.py
@@ -3,6 +3,7 @@ import logging
 import requests
 import json
 
+
 logger = logging.getLogger(__name__)
 
 
@@ -36,6 +37,7 @@ class NMDCSearch:
         filter: str = "",
         max_page_size: int = 100,
         fields: str = "",
+        auth_token: str = "",
     ):
         """
         Get all pages of data from the NMDC API. This is a helper function to get all pages of data from the NMDC API.
@@ -81,9 +83,9 @@ class NMDCSearch:
             headers = {
                 "accept": "application/json",
                 "Content-Type": "application/json",
-                "Authorization": f"Bearer {self.auth.get_token()}",
+                "Authorization": f"Bearer {auth_token}",
             }
-            url = f"{url_prefix}?filter={filter}&max_page_size={max_page_size}&projection={fields}&page_token={next_page_token}"
+
             try:
                 response = requests.get(
                     url_prefix, headers=headers, params=query_params

--- a/nmdc_api_utilities/nmdc_search.py
+++ b/nmdc_api_utilities/nmdc_search.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import logging
 import requests
+import json
 
 logger = logging.getLogger(__name__)
 
@@ -71,9 +72,22 @@ class NMDCSearch:
                 next_page_token = response.json()["next_page_token"]
             else:
                 break
+            query_params = {
+                "filter": f"{json.dumps(filter)}",
+                "max_page_size": max_page_size,
+                "projection": fields,
+                "page_token": next_page_token,
+            }
+            headers = {
+                "accept": "application/json",
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {self.auth.get_token()}",
+            }
             url = f"{url_prefix}?filter={filter}&max_page_size={max_page_size}&projection={fields}&page_token={next_page_token}"
             try:
-                response = requests.get(url)
+                response = requests.get(
+                    url_prefix, headers=headers, params=query_params
+                )
                 response.raise_for_status()
             except requests.exceptions.RequestException as e:
                 logger.error("API request failed", exc_info=True)

--- a/nmdc_api_utilities/nmdc_search.py
+++ b/nmdc_api_utilities/nmdc_search.py
@@ -80,10 +80,11 @@ class NMDCSearch:
                 "projection": fields,
                 "page_token": next_page_token,
             }
+
             headers = {
                 "accept": "application/json",
                 "Content-Type": "application/json",
-                "Authorization": f"Bearer {auth_token}",
+                "Authorization": f"Bearer {auth_token}" if auth_token else "",
             }
 
             try:

--- a/nmdc_api_utilities/nmdc_search.py
+++ b/nmdc_api_utilities/nmdc_search.py
@@ -84,9 +84,9 @@ class NMDCSearch:
             if isinstance(access_token, str):
                 headers["Authorization"] = f"Bearer {access_token}"
 
-            # TODO: Considering using the `params` argument of `requests.get` to handle building the
-            #       URL's query string. That way, we could delegate the responsibility of encoding
-            #       query parameters, to the `requests` library.
+            # TODO: Consider using the `params` argument of `requests.get` to handle building the
+            #       URL's query string. That way, we would be delegating the responsibility of
+            #       encoding query parameters, to the `requests` library.
             #       Reference: https://requests.readthedocs.io/en/latest/user/quickstart/#passing-parameters-in-urls
             #
             url = f"{url_prefix}?filter={filter}&max_page_size={max_page_size}&projection={fields}&page_token={next_page_token}"

--- a/nmdc_api_utilities/nmdc_search.py
+++ b/nmdc_api_utilities/nmdc_search.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 import logging
 import requests
-import json
-
+from typing import Optional
 
 logger = logging.getLogger(__name__)
 
@@ -37,7 +36,7 @@ class NMDCSearch:
         filter: str = "",
         max_page_size: int = 100,
         fields: str = "",
-        auth_token: str = "",
+        access_token: Optional[str] = None,
     ):
         """
         Get all pages of data from the NMDC API. This is a helper function to get all pages of data from the NMDC API.
@@ -54,6 +53,8 @@ class NMDCSearch:
             The maximum number of items to return per page. Default is 100.
         fields: str
             The fields to return. Default is all fields.
+        access_token: Optional[str]
+            Optional access token to include in the API request.
 
         Returns
         -------
@@ -74,18 +75,22 @@ class NMDCSearch:
                 next_page_token = response.json()["next_page_token"]
             else:
                 break
+
+            # Define the query parameters for getting the next page.
             query_params = {
-                "filter": f"{json.dumps(filter)}",
+                "filter": filter,
                 "max_page_size": max_page_size,
                 "projection": fields,
                 "page_token": next_page_token,
             }
 
+            # Define the HTTP headers, which may include an access token.
             headers = {
-                "accept": "application/json",
+                "Accept": "application/json",
                 "Content-Type": "application/json",
-                "Authorization": f"Bearer {auth_token}" if auth_token else "",
             }
+            if isinstance(access_token, str):
+                headers["Authorization"] = f"Bearer {access_token}"
 
             try:
                 response = requests.get(


### PR DESCRIPTION
- Changed the arguments for the call to _get_all_pages(). It was failing because the input was keyword arguments and one of the keywords was wrong. 
- NMDCAuth token was added as an optional argument to the calls to _get_app_pages()