### PR TITLE
Add links to `nmdc_notebooks` to documentation as example use cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,7 @@ cython_debug/
 # Sphinx documentation
 src/nmdc_api_utilities/docs/_build/
 package.zsh
+
+# Additional dev-related files
+.DS_Store
+.vscode/

--- a/docs/_static/external_links.js
+++ b/docs/_static/external_links.js
@@ -1,0 +1,18 @@
+document.addEventListener('DOMContentLoaded', function () {
+  try {
+    var links = document.querySelectorAll('a[href^="http"]');
+    links.forEach(function (a) {
+      // skip links that point to the same origin
+      try {
+        if (a.hostname && a.hostname !== location.hostname) {
+          a.setAttribute('target', '_blank');
+          a.setAttribute('rel', 'noopener noreferrer');
+        }
+      } catch (e) {
+        // ignore malformed URLs
+      }
+    });
+  } catch (e) {
+    // defensive: do nothing if querySelectorAll isn't supported
+  }
+});

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,3 +34,7 @@ exclude_patterns = ["build", "Thumbs.db", ".DS_Store"]
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
 html_theme = "sphinx_rtd_theme"
+html_static_path = ["_static"]
+html_js_files = [
+    "external_links.js",
+]

--- a/docs/example_usage.rst
+++ b/docs/example_usage.rst
@@ -5,12 +5,13 @@ This page collects example Jupyter notebooks that use the NMDC API Utilities pac
 These notebooks cover a range of topics, including how to use the package to retrieve and analyze data from the NMDC API,
 as well as how to integrate the package with other tools and libraries for data analysis and visualization.
 
-Note that these links will take you to notebooks in the [`nmdc_notebooks`](https://github.com/microbiomedata/nmdc_notebooks) repository, and may not be up-to-date with the latest version of the library.
-If you find any issues with the notebooks, please consider contributing a fix or opening an issue in the `nmdc_notebooks` repository.
-- `Bioscales Biogeochemical Metadata <https://microbiomedata.github.io/nmdc_notebooks/bioscales_python.html>`
-- `NEON Soil Metadata <https://microbiomedata.github.io/nmdc_notebooks/neon_python.html>`
-- `Taxonomy and Metadata Analysis <https://microbiomedata.github.io/nmdc_notebooks/taxonomic_python.html>`
-- `Visualization of NOM Data <https://microbiomedata.github.io/nmdc_notebooks/nom_python.html>`
-- `Integrating Metagenome-Metatranscriptome Data <https://microbiomedata.github.io/nmdc_notebooks/metagmetat_python.html>`
-- `Integrating 'Omics Types Analysis <https://microbiomedata.github.io/nmdc_notebooks/integration_python.html>`
-- `Over-representation Analysis <https://microbiomedata.github.io/nmdc_notebooks/overrepresentation_python.html>`
+Note that these links will take you to notebooks in the `nmdc_notebooks <https://github.com/microbiomedata/nmdc_notebooks>`_ repository, and may not be up-to-date with the latest version of the library.
+If you find any issues with the notebooks, please consider contributing a fix or opening an issue in the `nmdc_notebooks <https://github.com/microbiomedata/nmdc_notebooks>`_ repository.
+
+- `Bioscales Biogeochemical Metadata <https://microbiomedata.github.io/nmdc_notebooks/bioscales_python.html>`_
+- `NEON Soil Metadata <https://microbiomedata.github.io/nmdc_notebooks/neon_python.html>`_
+- `Taxonomy and Metadata Analysis <https://microbiomedata.github.io/nmdc_notebooks/taxonomic_python.html>`_
+- `Visualization of NOM Data <https://microbiomedata.github.io/nmdc_notebooks/nom_python.html>`_
+- `Integrating Metagenome-Metatranscriptome Data <https://microbiomedata.github.io/nmdc_notebooks/metagmetat_python.html>`_
+- `Integrating 'Omics Types Analysis <https://microbiomedata.github.io/nmdc_notebooks/integration_python.html>`_
+- `Over-representation Analysis <https://microbiomedata.github.io/nmdc_notebooks/overrepresentation_python.html>`_

--- a/docs/example_usage.rst
+++ b/docs/example_usage.rst
@@ -1,0 +1,16 @@
+Example Usage
+=============
+
+This page collects example Jupyter notebooks that use the NMDC API Utilities package to interact with the NMDC API.
+These notebooks cover a range of topics, including how to use the package to retrieve and analyze data from the NMDC API,
+as well as how to integrate the package with other tools and libraries for data analysis and visualization.
+
+Note that these links will take you to notebooks in the [`nmdc_notebooks`](https://github.com/microbiomedata/nmdc_notebooks) repository, and may not be up-to-date with the latest version of the library.
+If you find any issues with the notebooks, please consider contributing a fix or opening an issue in the `nmdc_notebooks` repository.
+- `Bioscales Biogeochemical Metadata <https://microbiomedata.github.io/nmdc_notebooks/bioscales_python.html>`
+- `NEON Soil Metadata <https://microbiomedata.github.io/nmdc_notebooks/neon_python.html>`
+- `Taxonomy and Metadata Analysis <https://microbiomedata.github.io/nmdc_notebooks/taxonomic_python.html>`
+- `Visualization of NOM Data <https://microbiomedata.github.io/nmdc_notebooks/nom_python.html>`
+- `Integrating Metagenome-Metatranscriptome Data <https://microbiomedata.github.io/nmdc_notebooks/metagmetat_python.html>`
+- `Integrating 'Omics Types Analysis <https://microbiomedata.github.io/nmdc_notebooks/integration_python.html>`
+- `Over-representation Analysis <https://microbiomedata.github.io/nmdc_notebooks/overrepresentation_python.html>`

--- a/docs/example_usage.rst
+++ b/docs/example_usage.rst
@@ -1,11 +1,11 @@
 Example Usage
 =============
 
-This page collects example Jupyter notebooks that use the NMDC API Utilities package to interact with the NMDC API.
+This page collects example Jupyter notebooks in the `nmdc_notebooks <https://github.com/microbiomedata/nmdc_notebooks>`_ repository
+that use the NMDC API Utilities package to interact with the NMDC API.
 These notebooks cover a range of topics, including how to use the package to retrieve and analyze data from the NMDC API,
 as well as how to integrate the package with other tools and libraries for data analysis and visualization.
 
-Note that these links will take you to notebooks in the `nmdc_notebooks <https://github.com/microbiomedata/nmdc_notebooks>`_ repository, and may not be up-to-date with the latest version of the library.
 If you find any issues with the notebooks, please consider contributing a fix or opening an issue in the `nmdc_notebooks <https://github.com/microbiomedata/nmdc_notebooks>`_ repository.
 
 - `Bioscales Biogeochemical Metadata <https://microbiomedata.github.io/nmdc_notebooks/bioscales_python.html>`_

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,6 +9,7 @@ Welcome to NMDC API Utilities documentation. This package provides tools for int
 
    functions
    usage
+   example_usage
 
 Indices and tables
 ==================


### PR DESCRIPTION
Closes #136 

Adds "Example Usage" to landing documentation page.
<img width="1075" height="1030" alt="Screenshot 2026-04-07 at 3 36 11 PM" src="https://github.com/user-attachments/assets/84ec5477-9b59-4ebf-8b71-bf8b9127b1b2" />

That page looks like this.
<img width="1118" height="707" alt="Screenshot 2026-04-07 at 3 48 37 PM" src="https://github.com/user-attachments/assets/21506912-6ae1-4396-bb56-09c36fa5bbb3" />

I (well co-pilot if I'm being honest) added a small JS asset (and enabled it in Sphinx) so external links (like those on the Example Usage page shown above) open the links to the nmdc_notebooks repo in a new browser tab/window.  All non-external links are not affected.

I've checked all the links on the new page locally during local testing.

Also added a couple small things to the .gitignore.