### PR TITLE
Customize "User-Agent" HTTP header to `nmdc-python-client/{version}`

### DIFF
--- a/nmdc_api_utilities/__init__.py
+++ b/nmdc_api_utilities/__init__.py
@@ -1,19 +1,31 @@
 # -*- coding: utf-8 -*-
-# __init__.py
-
-# Import necessary modules or packages here
-
-# Define the package version
-__version__ = "0.1.0"
-
-# Initialize package-level variables or configurations if needed
-# config_variable = "value"
-
-# You can also include package-level docstring
 """
-nmdc_api_utilities package
+This file contains (or will contain) two kinds of things:
+(1) metadata about this package, itself; and
+(2) things that we want to make it particularly convenient for package users to import.
 
-This package provides tools for working with NMDC notebooks.
+Reference: https://realpython.com/python-init-py/#what-kind-of-code-should-i-put-in-__init__py
 """
 
-# Add any other initialization code here
+from importlib.metadata import PackageNotFoundError, version
+from typing import Optional
+
+
+def get_package_version(package_name: str) -> Optional[str]:
+    """
+    Returns the version identifier (e.g., "1.2.3") of the package having the specified name.
+
+    Args:
+        package_name: The name of the package
+
+    Returns:
+        The version identifier of the package, or `None` if package not found
+    """
+    try:
+        return version(package_name)
+    except PackageNotFoundError:
+        return None
+
+
+# The version identifier of this package.
+__version__ = get_package_version("nmdc_api_utilities")

--- a/nmdc_api_utilities/__init__.py
+++ b/nmdc_api_utilities/__init__.py
@@ -28,4 +28,5 @@ def get_package_version(package_name: str) -> Optional[str]:
 
 
 # The version identifier of this package.
-__version__ = get_package_version("nmdc_api_utilities")
+_version = get_package_version("nmdc_api_utilities")
+__version__ = _version if _version is not None else "0.0.0"

--- a/nmdc_api_utilities/auth.py
+++ b/nmdc_api_utilities/auth.py
@@ -98,7 +98,14 @@ class NMDCAuth(NMDCSearch):
                 "password": self.password,
             }
 
-        response = requests.post(f"{self.api_base_url}/token", data=token_request_body)
+        # TODO: If `self.grant_type` is neither "client_credentials" nor "password",
+        #       `token_request_body` below will be unbound. Handle that situation.
+
+        response = requests.post(
+            f"{self.api_base_url}/token",
+            headers=self._build_http_request_headers(),
+            data=token_request_body,
+        )
         token_response = response.json()
 
         if "access_token" not in token_response:

--- a/nmdc_api_utilities/collection_search.py
+++ b/nmdc_api_utilities/collection_search.py
@@ -69,7 +69,10 @@ class CollectionSearch(NMDCSearch):
         url_prefix = f"{self.api_base_url}/nmdcschema/{self.collection_name}"
         url = f"{url_prefix}?filter={filter}&max_page_size={max_page_size}&projection={fields}"
         try:
-            response = requests.get(url)
+            response = requests.get(
+                url,
+                headers=self._build_http_request_headers(),
+            )
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
             logger.error("API request failed", exc_info=True)
@@ -195,7 +198,10 @@ class CollectionSearch(NMDCSearch):
         url = f"{self.api_base_url}/nmdcschema/{self.collection_name}/{collection_id}?max_page_size={max_page_size}&projection={fields}"
         # get the reponse
         try:
-            response = requests.get(url)
+            response = requests.get(
+                url,
+                headers=self._build_http_request_headers(),
+            )
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
             logger.error("API request failed", exc_info=True)

--- a/nmdc_api_utilities/data_object_search.py
+++ b/nmdc_api_utilities/data_object_search.py
@@ -44,7 +44,10 @@ class DataObjectSearch(CollectionSearch):
         """
         url = f"{self.api_base_url}/data_objects/study/{study_id}?max_page_size={max_page_size}"
         try:
-            response = requests.get(url)
+            response = requests.get(
+                url,
+                headers=self._build_http_request_headers(),
+            )
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
             logger.error("API request failed", exc_info=True)

--- a/nmdc_api_utilities/data_staging.py
+++ b/nmdc_api_utilities/data_staging.py
@@ -240,7 +240,9 @@ class JGISampleSearchAPI(NMDCSearch):
             }
             response = requests.get(
                 url,
-                headers=self._build_http_request_headers(access_token=self.auth.get_token()),
+                headers=self._build_http_request_headers(
+                    access_token=self.auth.get_token()
+                ),
                 params=query_params,
             )
             response.raise_for_status()

--- a/nmdc_api_utilities/data_staging.py
+++ b/nmdc_api_utilities/data_staging.py
@@ -65,11 +65,11 @@ class JGISequencingProjectAPI(NMDCSearch):
         """
 
         url = f"{self.api_base_url}/wf_file_staging/jgi_sequencing_projects"
-        headers = {
-            "accept": "application/json",
-            "Content-Type": "application/json",
-            "Authorization": f"Bearer {self.auth.get_token()}",
-        }
+        headers = self._build_http_request_headers(
+            access_token=self.auth.get_token(),
+            accept="application/json",
+            content_type="application/json",
+        )
         try:
             response = requests.post(url, headers=headers, json=jgi_sequencing_project)
             response.raise_for_status()
@@ -111,11 +111,11 @@ class JGISequencingProjectAPI(NMDCSearch):
             The list of JGI sequencing projects.
         """
         url = f"{self.api_base_url}/wf_file_staging/jgi_sequencing_projects"
-        headers = {
-            "accept": "application/json",
-            "Content-Type": "application/json",
-            "Authorization": f"Bearer {self.auth.get_token()}",
-        }
+        headers = self._build_http_request_headers(
+            access_token=self.auth.get_token(),
+            accept="application/json",
+            content_type="application/json",
+        )
         try:
             query_params = {
                 "filter": f"{json.dumps(filter)}",
@@ -159,10 +159,10 @@ class JGISequencingProjectAPI(NMDCSearch):
             The JGI sequencing project record.
         """
         url = f"{self.api_base_url}/wf_file_staging/jgi_sequencing_projects/{project_name}"
-        headers = {
-            "accept": "application/json",
-            "Authorization": f"Bearer {self.auth.get_token()}",
-        }
+        headers = self._build_http_request_headers(
+            access_token=self.auth.get_token(),
+            accept="application/json",
+        )
         try:
             response = requests.get(url, headers=headers)
             response.raise_for_status()
@@ -240,7 +240,7 @@ class JGISampleSearchAPI(NMDCSearch):
             }
             response = requests.get(
                 url,
-                headers={"Authorization": f"Bearer {self.auth.get_token()}"},
+                headers=self._build_http_request_headers(access_token=self.auth.get_token()),
                 params=query_params,
             )
             response.raise_for_status()
@@ -289,11 +289,11 @@ class JGISampleSearchAPI(NMDCSearch):
             If the insertion fails.
         """
         url = f"{self.api_base_url}/wf_file_staging/jgi_samples"
-        headers = {
-            "accept": "application/json",
-            "Content-Type": "application/json",
-            "Authorization": f"Bearer {self.auth.get_token()}",
-        }
+        headers = self._build_http_request_headers(
+            access_token=self.auth.get_token(),
+            accept="application/json",
+            content_type="application/json",
+        )
         try:
             response = requests.post(url, headers=headers, json=jgi_sample)
             response.raise_for_status()
@@ -336,11 +336,11 @@ class JGISampleSearchAPI(NMDCSearch):
             If the update fails.
         """
         url = f"{self.api_base_url}/wf_file_staging/jgi_samples/{jgi_file_id}"
-        headers = {
-            "accept": "application/json",
-            "Content-Type": "application/json",
-            "Authorization": f"Bearer {self.auth.get_token()}",
-        }
+        headers = self._build_http_request_headers(
+            access_token=self.auth.get_token(),
+            accept="application/json",
+            content_type="application/json",
+        )
         try:
             response = requests.patch(url, headers=headers, json=jgi_sample)
             response.raise_for_status()
@@ -409,11 +409,11 @@ class GlobusTaskAPI(NMDCSearch):
             The list of Globus task records.
         """
         url = f"{self.api_base_url}/wf_file_staging/globus_tasks"
-        headers = {
-            "accept": "application/json",
-            "Content-Type": "application/json",
-            "Authorization": f"Bearer {self.auth.get_token()}",
-        }
+        headers = self._build_http_request_headers(
+            access_token=self.auth.get_token(),
+            accept="application/json",
+            content_type="application/json",
+        )
         query_params = {
             "filter": f"{json.dumps(filter)}",
             "max_page_size": max_page_size,
@@ -462,11 +462,11 @@ class GlobusTaskAPI(NMDCSearch):
         """
 
         url = f"{self.api_base_url}/wf_file_staging/globus_tasks"
-        headers = {
-            "accept": "application/json",
-            "Content-Type": "application/json",
-            "Authorization": f"Bearer {self.auth.get_token()}",
-        }
+        headers = self._build_http_request_headers(
+            access_token=self.auth.get_token(),
+            accept="application/json",
+            content_type="application/json",
+        )
         try:
             response = requests.post(url, headers=headers, json=globus_task)
             response.raise_for_status()
@@ -509,11 +509,11 @@ class GlobusTaskAPI(NMDCSearch):
             If the update fails.
         """
         url = f"{self.api_base_url}/wf_file_staging/globus_tasks/{globus_task_id}"
-        headers = {
-            "accept": "application/json",
-            "Content-Type": "application/json",
-            "Authorization": f"Bearer {self.auth.get_token()}",
-        }
+        headers = self._build_http_request_headers(
+            access_token=self.auth.get_token(),
+            accept="application/json",
+            content_type="application/json",
+        )
         try:
             response = requests.patch(url, headers=headers, json=globus_task)
             response.raise_for_status()

--- a/nmdc_api_utilities/metadata.py
+++ b/nmdc_api_utilities/metadata.py
@@ -66,7 +66,10 @@ class Metadata(NMDCSearch):
             raise Exception("Placeholder values found in json!")
 
         url = f"{self.api_base_url}/metadata/json:validate"
-        headers = {"accept": "application/json", "Content-Type": "application/json"}
+        headers = self._build_http_request_headers(
+            accept="application/json",
+            content_type="application/json",
+        )
         response = requests.post(url, headers=headers, json=data)
         if response.text != '{"result":"All Okay!"}' or response.status_code != 200:
             logging.error(f"Validation failed.")
@@ -110,11 +113,11 @@ class Metadata(NMDCSearch):
 
         # api request
         url = f"{self.api_base_url}/metadata/json:submit"
-        headers = {
-            "accept": "application/json",
-            "Content-Type": "application/json",
-            "Authorization": f"Bearer {token}",
-        }
+        headers = self._build_http_request_headers(
+            access_token=token,
+            accept="application/json",
+            content_type="application/json",
+        )
         response = requests.post(url, headers=headers, json=json_records)
 
         # error handling

--- a/nmdc_api_utilities/minter.py
+++ b/nmdc_api_utilities/minter.py
@@ -97,7 +97,7 @@ class Minter(NMDCSearch):
         try:
             response = requests.post(
                 url,
-                headers={"Authorization": f"Bearer {token}"},
+                headers=self._build_http_request_headers(access_token=token),
                 data=json.dumps(payload),
             )
             response.raise_for_status()

--- a/nmdc_api_utilities/nmdc_search.py
+++ b/nmdc_api_utilities/nmdc_search.py
@@ -5,6 +5,7 @@ from typing import Optional
 
 import requests
 
+from nmdc_api_utilities import __version__ as package_version
 from nmdc_api_utilities.config import API_BASE_URL, get_api_base_url
 
 logger = logging.getLogger(__name__)
@@ -31,6 +32,46 @@ class NMDCSearch:
                 DeprecationWarning,
             )
         self.api_base_url = get_api_base_url(api_base_url=api_base_url, env=env)
+
+    def _build_http_request_headers(
+        self,
+        access_token: Optional[str] = None,
+        accept: Optional[str] = None,
+        content_type: Optional[str] = None,
+        additional_headers: Optional[dict[str, str]] = None,
+    ) -> dict[str, str]:
+        """
+        Builds HTTP headers that can be included with HTTP requests sent by instances of this class
+        and its subclasses.
+
+        >>> searcher = NMDCSearch()
+        >>> headers = searcher._build_http_request_headers(
+        ...     access_token="abc123",
+        ...     accept="application/json",
+        ...     additional_headers={"X-FOO": "BAR"},
+        ... )
+        >>> assert headers.keys() == {"User-Agent", "Authorization", "Accept", "X-FOO"}
+        >>> assert headers["User-Agent"].startswith("nmdc-python-client/")
+        >>> assert headers["Authorization"] == "Bearer abc123"
+        >>> assert headers["Accept"] == "application/json"
+        >>> assert headers["X-FOO"] == "BAR"
+        """
+
+        # Customize the "User-Agent" header so NMDC API administrators can distinguish requests
+        # coming from this package from other requests. When not using a distributable version
+        # of this package, the package version will be "None".
+        user_agent = f"nmdc-python-client/{package_version}"
+        headers = {"User-Agent": user_agent}
+
+        if isinstance(access_token, str):
+            headers["Authorization"] = f"Bearer {access_token}"
+        if isinstance(accept, str):
+            headers["Accept"] = accept
+        if isinstance(content_type, str):
+            headers["Content-Type"] = content_type
+        if additional_headers is not None:
+            headers.update(additional_headers)
+        return headers
 
     def _get_all_pages(
         self,
@@ -80,12 +121,11 @@ class NMDCSearch:
                 break
 
             # Define the HTTP headers, which may include an access token.
-            headers = {
-                "Accept": "application/json",
-                "Content-Type": "application/json",
-            }
-            if isinstance(access_token, str):
-                headers["Authorization"] = f"Bearer {access_token}"
+            headers = self._build_http_request_headers(
+                access_token=access_token,
+                accept="application/json",
+                content_type="application/json",
+            )
 
             # TODO: Consider using the `params` argument of `requests.get` to handle building the
             #       URL's query string. That way, we would be delegating the responsibility of
@@ -145,7 +185,11 @@ class NMDCSearch:
                 "hydrate": hydrate,
                 "max_page_size": max_page_size,
             }
-            response = requests.get(url=url, params=params)
+            response = requests.get(
+                url=url,
+                params=params,
+                headers=self._build_http_request_headers(),
+            )
             if response.status_code == 200:
                 batch_resources = response.json().get("resources", [])
                 next_page = response.json().get("next_page_token", None)
@@ -157,7 +201,11 @@ class NMDCSearch:
                             "ids": batch,
                             "page_token": next_page,
                         }
-                        response = requests.get(url=url, params=params)
+                        response = requests.get(
+                            url=url,
+                            params=params,
+                            headers=self._build_http_request_headers(),
+                        )
                         if response.status_code == 200:
                             batch_resources = response.json().get("resources", [])
                             batch_records.extend(batch_resources)
@@ -243,7 +291,7 @@ class NMDCSearch:
         """
         url = f"{self.api_base_url}/nmdcschema/ids/{doc_id}/collection-name"
         try:
-            response = requests.get(url)
+            response = requests.get(url, headers=self._build_http_request_headers())
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
             logger.error("API request failed", exc_info=True)
@@ -321,7 +369,7 @@ class NMDCSearch:
 
         url = f"{self.api_base_url}/version"
         try:
-            response = requests.get(url)
+            response = requests.get(url, headers=self._build_http_request_headers())
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
             logger.error("API request failed", exc_info=True)
@@ -353,7 +401,11 @@ class NMDCSearch:
             "projection": fields,
         }
         try:
-            response = requests.get(url, params=params)
+            response = requests.get(
+                url,
+                params=params,
+                headers=self._build_http_request_headers(),
+            )
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
             logger.error("API request failed", exc_info=True)

--- a/nmdc_api_utilities/nmdc_search.py
+++ b/nmdc_api_utilities/nmdc_search.py
@@ -58,8 +58,8 @@ class NMDCSearch:
         """
 
         # Customize the "User-Agent" header so NMDC API administrators can distinguish requests
-        # coming from this package from other requests. When not using a distributable version
-        # of this package, the package version will be "None".
+        # coming from this package from other requests. If this package is being run from source
+        # instead of an installed distribution, the package version will be "0.0.0".
         user_agent = f"nmdc-python-client/{package_version}"
         headers = {"User-Agent": user_agent}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,3 +21,8 @@ license-files = ["LICENSE"]
 dynamic = ["dependencies"]
 [tool.setuptools.dynamic]
 dependencies = {file = ["requirements.txt"]}
+
+# Configure pytest.
+# Docs: https://docs.pytest.org/en/stable/reference/customize.html#pyproject-toml
+[tool.pytest]
+addopts = ["--doctest-modules"]  # run doctests defined in _all_ modules (not only `test_*` modules)


### PR DESCRIPTION
On this branch, I made it so, when the package sends an HTTP request, it includes an HTTP header that identifies the user agent as `nmdc-python-client/{version}` (e.g. `nmdc-python-client/0.6.1`).

This will allow Runtime administrators/Cloudflare users to distinguish incoming requests sent by this package, from those sent by other HTTP clients (e.g. web browsers, other scripts that use `requests` or `httpx`).

Note: The version number is only available when this package is installed in "distributable" form . When running in "source code" form, the user agent will be `nmdc-python-client/0.0.0`. By the way, `nmdc-python-client` is what I propose this repo and package eventually be renamed to.

- Fixes #151
- Fixes #152