### PR TITLE
Reroot classes to separate public and privileged endpoints

### DIFF
--- a/nmdc_api_utilities/api_client.py
+++ b/nmdc_api_utilities/api_client.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 class NMDCAPIClient(ABC):
     """
-    Abstract base class for interacting with NMDC runtime API.
+    Abstract base class for interacting with NMDC Runtime API.
 
     Parameters
     ----------

--- a/nmdc_api_utilities/api_client.py
+++ b/nmdc_api_utilities/api_client.py
@@ -33,8 +33,8 @@ class NMDCAPIClient(ABC):
             )
         self.api_base_url = get_api_base_url(api_base_url=api_base_url, env=env)
 
+    @staticmethod
     def _build_http_request_headers(
-        self,
         access_token: Optional[str] = None,
         accept: Optional[str] = None,
         content_type: Optional[str] = None,
@@ -44,9 +44,8 @@ class NMDCAPIClient(ABC):
         Builds HTTP headers that can be included with HTTP requests sent by instances of this class
         and its subclasses.
 
-        >>> from nmdc_api_utilities.nmdc_search import NMDCSearch
-        >>> searcher = NMDCSearch()
-        >>> headers = searcher._build_http_request_headers(
+        >>> from nmdc_api_utilities.api_client import NMDCAPIClient
+        >>> headers = NMDCAPIClient._build_http_request_headers(
         ...     access_token="abc123",
         ...     accept="application/json",
         ...     additional_headers={"X-FOO": "BAR"},

--- a/nmdc_api_utilities/api_client.py
+++ b/nmdc_api_utilities/api_client.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+import logging
+import warnings
+from abc import ABC
+
+from nmdc_api_utilities.config import API_BASE_URL, get_api_base_url
+
+logger = logging.getLogger(__name__)
+
+
+class NMDCAPIClient(ABC):
+    """
+    Abstract base class for interacting with NMDC runtime API.
+
+    Parameters
+    ----------
+    api_base_url: str
+        The base URL of an instance of the NMDC Runtime API. By default, this is the base URL of
+        the production instance. NMDC team members will occasionally set this to the base URL of
+        a different instance; for example, a self-hosted instance used for testing.
+    """
+
+    def __init__(self, api_base_url: str = API_BASE_URL, env: str = ""):
+        if env != "":
+            warnings.warn(
+                "`env` is deprecated and will be removed in a future release. "
+                "Use `api_base_url` instead.",
+                DeprecationWarning,
+            )
+        self.api_base_url = get_api_base_url(api_base_url=api_base_url, env=env)

--- a/nmdc_api_utilities/api_client.py
+++ b/nmdc_api_utilities/api_client.py
@@ -2,7 +2,11 @@
 import logging
 import warnings
 from abc import ABC
+from typing import Optional
 
+import requests
+
+from nmdc_api_utilities import __version__ as package_version
 from nmdc_api_utilities.config import API_BASE_URL, get_api_base_url
 
 logger = logging.getLogger(__name__)
@@ -28,3 +32,117 @@ class NMDCAPIClient(ABC):
                 DeprecationWarning,
             )
         self.api_base_url = get_api_base_url(api_base_url=api_base_url, env=env)
+
+    def _build_http_request_headers(
+        self,
+        access_token: Optional[str] = None,
+        accept: Optional[str] = None,
+        content_type: Optional[str] = None,
+        additional_headers: Optional[dict[str, str]] = None,
+    ) -> dict[str, str]:
+        """
+        Builds HTTP headers that can be included with HTTP requests sent by instances of this class
+        and its subclasses.
+
+        >>> from nmdc_api_utilities.nmdc_search import NMDCSearch
+        >>> searcher = NMDCSearch()
+        >>> headers = searcher._build_http_request_headers(
+        ...     access_token="abc123",
+        ...     accept="application/json",
+        ...     additional_headers={"X-FOO": "BAR"},
+        ... )
+        >>> assert headers.keys() == {"User-Agent", "Authorization", "Accept", "X-FOO"}
+        >>> assert headers["User-Agent"].startswith("nmdc-python-client/")
+        >>> assert headers["Authorization"] == "Bearer abc123"
+        >>> assert headers["Accept"] == "application/json"
+        >>> assert headers["X-FOO"] == "BAR"
+        """
+
+        # Customize the "User-Agent" header so NMDC API administrators can distinguish requests
+        # coming from this package from other requests. If this package is being run from source
+        # instead of an installed distribution, the package version will be "0.0.0".
+        user_agent = f"nmdc-python-client/{package_version}"
+        headers = {"User-Agent": user_agent}
+
+        if isinstance(access_token, str):
+            headers["Authorization"] = f"Bearer {access_token}"
+        if isinstance(accept, str):
+            headers["Accept"] = accept
+        if isinstance(content_type, str):
+            headers["Content-Type"] = content_type
+        if additional_headers is not None:
+            headers.update(additional_headers)
+        return headers
+
+    def _get_all_pages(
+        self,
+        response: requests.Response,
+        url_prefix: str,
+        filter: str = "",
+        max_page_size: int = 100,
+        fields: str = "",
+        access_token: Optional[str] = None,
+    ):
+        """
+        Get all pages of data from the NMDC API. This is a helper function to get all pages of data from the NMDC API.
+
+        Parameters
+        ----------
+        response: requests.Response
+            The response object from the API request. Do not modify before passing in.
+        url_prefix: str
+            The URL prefix for the API endpoint.
+        filter: str
+            The filter to apply to the query. Default is an empty string.
+        max_page_size: int
+            The maximum number of items to return per page. Default is 100.
+        fields: str
+            The fields to return. Default is all fields.
+        access_token: Optional[str]
+            Optional access token to include in the API request.
+
+        Returns
+        -------
+        list[dict]
+            A list of dictionaries containing the records.
+
+        Raises
+        ------
+        RuntimeError
+            If the API request fails.
+
+        """
+
+        results = response.json()
+
+        while True:
+            if response.json().get("next_page_token"):
+                next_page_token = response.json()["next_page_token"]
+            else:
+                break
+
+            # Define the HTTP headers, which may include an access token.
+            headers = self._build_http_request_headers(
+                access_token=access_token,
+                accept="application/json",
+                content_type="application/json",
+            )
+
+            # TODO: Consider using the `params` argument of `requests.get` to handle building the
+            #       URL's query string. That way, we would be delegating the responsibility of
+            #       encoding query parameters, to the `requests` library.
+            #       Reference: https://requests.readthedocs.io/en/latest/user/quickstart/#passing-parameters-in-urls
+            #
+            url = f"{url_prefix}?filter={filter}&max_page_size={max_page_size}&projection={fields}&page_token={next_page_token}"
+            try:
+                response = requests.get(url, headers=headers)
+                response.raise_for_status()
+            except requests.exceptions.RequestException as e:
+                logger.error("API request failed", exc_info=True)
+                raise RuntimeError("Failed to get collection from NMDC API") from e
+            else:
+                logging.debug(
+                    f"API request response: {response.json()}\n API Status Code: {response.status_code}"
+                )
+            results = {"resources": results["resources"] + response.json()["resources"]}
+        return results

--- a/nmdc_api_utilities/auth.py
+++ b/nmdc_api_utilities/auth.py
@@ -5,13 +5,13 @@ from datetime import datetime, timedelta
 
 import requests
 
+from nmdc_api_utilities.api_client import NMDCAPIClient
 from nmdc_api_utilities.config import API_BASE_URL
-from nmdc_api_utilities.nmdc_search import NMDCSearch
 
 logger = logging.getLogger(__name__)
 
 
-class NMDCAuth(NMDCSearch):
+class NMDCAuth(NMDCAPIClient):
     """
     Authentication handler for NMDC API operations.
 

--- a/nmdc_api_utilities/collection_search.py
+++ b/nmdc_api_utilities/collection_search.py
@@ -14,6 +14,12 @@ from nmdc_api_utilities.nmdc_search import NMDCSearch
 logger = logging.getLogger(__name__)
 
 
+class OperationNotSupportedError(RuntimeError):
+    """Raised when an operation isn't supported by a collection subclass."""
+
+    pass
+
+
 class CollectionSearch(NMDCSearch):
     """
     Class to interact with the NMDC API to get collections of data. Must know the collection name to query.
@@ -195,6 +201,11 @@ class CollectionSearch(NMDCSearch):
             If the API request fails.
 
         """
+        if not getattr(self, "supports_get_by_id", True):
+            raise OperationNotSupportedError(
+                f"get_record_by_id is not supported for the {self.collection_name} collection"
+            )
+
         url = f"{self.api_base_url}/nmdcschema/{self.collection_name}/{collection_id}?max_page_size={max_page_size}&projection={fields}"
         # get the reponse
         try:
@@ -236,6 +247,11 @@ class CollectionSearch(NMDCSearch):
             True if all IDs exist in the collection, False otherwise.
 
         """
+        if not getattr(self, "supports_get_by_id", True):
+            raise OperationNotSupportedError(
+                f"check_ids_exist is not supported for the {self.collection_name} collection"
+            )
+
         # chunk the input list of IDs into smaller lists of 100 IDs each
         # to avoid the maximum URL length limit
         ids_test = list(set(ids))
@@ -280,6 +296,11 @@ class CollectionSearch(NMDCSearch):
             A list of dictionaries containing the records.
 
         """
+        if not getattr(self, "supports_get_by_id", True):
+            raise OperationNotSupportedError(
+                f"get_record_by_id is not supported for the {self.collection_name} collection"
+            )
+
         dp = DataProcessing()
         results = []
         id_list = list(set(id_list))

--- a/nmdc_api_utilities/data_staging.py
+++ b/nmdc_api_utilities/data_staging.py
@@ -4,15 +4,15 @@ import logging
 
 import requests
 
+from nmdc_api_utilities.api_client import NMDCAPIClient
 from nmdc_api_utilities.auth import NMDCAuth
 from nmdc_api_utilities.config import API_BASE_URL
 from nmdc_api_utilities.decorators import requires_auth
-from nmdc_api_utilities.nmdc_search import NMDCSearch
 
 logger = logging.getLogger(__name__)
 
 
-class JGISequencingProjectAPI(NMDCSearch):
+class JGISequencingProjectAPI(NMDCAPIClient):
     """
     Class to interact with the NMDC API to get JGI samples.
     """
@@ -177,7 +177,7 @@ class JGISequencingProjectAPI(NMDCSearch):
         return response.json()
 
 
-class JGISampleSearchAPI(NMDCSearch):
+class JGISampleSearchAPI(NMDCAPIClient):
     """
     Class to interact with the NMDC API to get JGI samples.
     """
@@ -357,7 +357,7 @@ class JGISampleSearchAPI(NMDCSearch):
         return response.json()
 
 
-class GlobusTaskAPI(NMDCSearch):
+class GlobusTaskAPI(NMDCAPIClient):
     """
     Class to interact with the NMDC API for Globus tasks.
     """

--- a/nmdc_api_utilities/functional_search.py
+++ b/nmdc_api_utilities/functional_search.py
@@ -4,13 +4,15 @@ from nmdc_api_utilities.collection_search import CollectionSearch
 from nmdc_api_utilities.config import API_BASE_URL
 
 
-class FunctionalSearch:
+class FunctionalSearch(CollectionSearch):
     """
     Class to interact with the NMDC API to filter functional annotations by KEGG, COG, or PFAM ids.
     """
 
+    supports_get_by_id = False
+
     def __init__(self, api_base_url: str = API_BASE_URL, env: str = ""):
-        self.collectioninstance = CollectionSearch(
+        super().__init__(
             collection_name="functional_annotation_agg",
             api_base_url=api_base_url,
             env=env,
@@ -61,36 +63,5 @@ class FunctionalSearch:
 
         filter = f'{{"gene_function_id": "{formatted_annotation_type}"}}'
 
-        result = self.collectioninstance.get_record_by_filter(
-            filter, page_size, fields, all_pages
-        )
+        result = self.get_record_by_filter(filter, page_size, fields, all_pages)
         return result
-
-    def get_records(
-        self,
-        filter: str = "",
-        max_page_size: int = 100,
-        fields: str = "",
-        all_pages: bool = False,
-    ) -> list[dict]:
-        """
-        Get a collection of data from the NMDC API. Generic function to get a collection of data from the NMDC API. Can provide a specific filter if desired.
-
-        Parameters
-        ----------
-        filter: str
-            The filter to apply to the query. Default is an empty string.
-        max_page_size: int
-            The maximum number of items to return per page. Default is 100.
-        fields: str
-            The fields to return. Default is all fields.
-
-        Returns
-        -------
-        list[dict]
-            A list of records.
-
-        """
-        return self.collectioninstance.get_records(
-            filter, max_page_size, fields, all_pages
-        )

--- a/nmdc_api_utilities/metadata.py
+++ b/nmdc_api_utilities/metadata.py
@@ -4,15 +4,15 @@ import logging
 
 import requests
 
+from nmdc_api_utilities.api_client import NMDCAPIClient
 from nmdc_api_utilities.auth import NMDCAuth
 from nmdc_api_utilities.config import API_BASE_URL
 from nmdc_api_utilities.decorators import requires_auth
-from nmdc_api_utilities.nmdc_search import NMDCSearch
 
 logger = logging.getLogger(__name__)
 
 
-class Metadata(NMDCSearch):
+class Metadata(NMDCAPIClient):
     """
     Class to interact with the NMDC API metadata endpoints. These deal mostly with metadata management, including validation and submission.
 

--- a/nmdc_api_utilities/minter.py
+++ b/nmdc_api_utilities/minter.py
@@ -4,15 +4,15 @@ import logging
 
 import requests
 
+from nmdc_api_utilities.api_client import NMDCAPIClient
 from nmdc_api_utilities.auth import NMDCAuth
 from nmdc_api_utilities.config import API_BASE_URL
 from nmdc_api_utilities.decorators import requires_auth
-from nmdc_api_utilities.nmdc_search import NMDCSearch
 
 logger = logging.getLogger(__name__)
 
 
-class Minter(NMDCSearch):
+class Minter(NMDCAPIClient):
     """
     Class to interact with the NMDC API to mint new identifiers.
 

--- a/nmdc_api_utilities/nmdc_search.py
+++ b/nmdc_api_utilities/nmdc_search.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 class NMDCSearch(NMDCAPIClient):
     """
-    Base class for searching the NMDC metadata database via the NMDC runtime API
+    Base class for searching the NMDC metadata database via the NMDC Runtime API
 
     Parameters
     ----------

--- a/nmdc_api_utilities/nmdc_search.py
+++ b/nmdc_api_utilities/nmdc_search.py
@@ -5,14 +5,15 @@ from typing import Optional
 
 import requests
 
-from nmdc_api_utilities.config import API_BASE_URL, get_api_base_url
+from nmdc_api_utilities.api_client import NMDCAPIClient
+from nmdc_api_utilities.config import API_BASE_URL
 
 logger = logging.getLogger(__name__)
 
 
-class NMDCSearch:
+class NMDCSearch(NMDCAPIClient):
     """
-    Base class for interacting with the NMDC API.
+    Base class for searching the NMDC metadata database via the NMDC runtime API
 
     Parameters
     ----------
@@ -24,13 +25,7 @@ class NMDCSearch:
     """
 
     def __init__(self, api_base_url: str = API_BASE_URL, env: str = ""):
-        if env != "":
-            warnings.warn(
-                "`env` is deprecated and will be removed in a future release. "
-                "Use `api_base_url` instead.",
-                DeprecationWarning,
-            )
-        self.api_base_url = get_api_base_url(api_base_url=api_base_url, env=env)
+        super().__init__(api_base_url=api_base_url, env=env)
 
     def _get_all_pages(
         self,

--- a/nmdc_api_utilities/nmdc_search.py
+++ b/nmdc_api_utilities/nmdc_search.py
@@ -1,11 +1,8 @@
 # -*- coding: utf-8 -*-
 import logging
-import warnings
-from typing import Optional
 
 import requests
 
-from nmdc_api_utilities import __version__ as package_version
 from nmdc_api_utilities.api_client import NMDCAPIClient
 from nmdc_api_utilities.config import API_BASE_URL
 
@@ -27,119 +24,6 @@ class NMDCSearch(NMDCAPIClient):
 
     def __init__(self, api_base_url: str = API_BASE_URL, env: str = ""):
         super().__init__(api_base_url=api_base_url, env=env)
-
-    def _build_http_request_headers(
-        self,
-        access_token: Optional[str] = None,
-        accept: Optional[str] = None,
-        content_type: Optional[str] = None,
-        additional_headers: Optional[dict[str, str]] = None,
-    ) -> dict[str, str]:
-        """
-        Builds HTTP headers that can be included with HTTP requests sent by instances of this class
-        and its subclasses.
-
-        >>> searcher = NMDCSearch()
-        >>> headers = searcher._build_http_request_headers(
-        ...     access_token="abc123",
-        ...     accept="application/json",
-        ...     additional_headers={"X-FOO": "BAR"},
-        ... )
-        >>> assert headers.keys() == {"User-Agent", "Authorization", "Accept", "X-FOO"}
-        >>> assert headers["User-Agent"].startswith("nmdc-python-client/")
-        >>> assert headers["Authorization"] == "Bearer abc123"
-        >>> assert headers["Accept"] == "application/json"
-        >>> assert headers["X-FOO"] == "BAR"
-        """
-
-        # Customize the "User-Agent" header so NMDC API administrators can distinguish requests
-        # coming from this package from other requests. If this package is being run from source
-        # instead of an installed distribution, the package version will be "0.0.0".
-        user_agent = f"nmdc-python-client/{package_version}"
-        headers = {"User-Agent": user_agent}
-
-        if isinstance(access_token, str):
-            headers["Authorization"] = f"Bearer {access_token}"
-        if isinstance(accept, str):
-            headers["Accept"] = accept
-        if isinstance(content_type, str):
-            headers["Content-Type"] = content_type
-        if additional_headers is not None:
-            headers.update(additional_headers)
-        return headers
-
-    def _get_all_pages(
-        self,
-        response: requests.Response,
-        url_prefix: str,
-        filter: str = "",
-        max_page_size: int = 100,
-        fields: str = "",
-        access_token: Optional[str] = None,
-    ):
-        """
-        Get all pages of data from the NMDC API. This is a helper function to get all pages of data from the NMDC API.
-
-        Parameters
-        ----------
-        response: requests.Response
-            The response object from the API request. Do not modify before passing in.
-        url_prefix: str
-            The URL prefix for the API endpoint.
-        filter: str
-            The filter to apply to the query. Default is an empty string.
-        max_page_size: int
-            The maximum number of items to return per page. Default is 100.
-        fields: str
-            The fields to return. Default is all fields.
-        access_token: Optional[str]
-            Optional access token to include in the API request.
-
-        Returns
-        -------
-        list[dict]
-            A list of dictionaries containing the records.
-
-        Raises
-        ------
-        RuntimeError
-            If the API request fails.
-
-        """
-
-        results = response.json()
-
-        while True:
-            if response.json().get("next_page_token"):
-                next_page_token = response.json()["next_page_token"]
-            else:
-                break
-
-            # Define the HTTP headers, which may include an access token.
-            headers = self._build_http_request_headers(
-                access_token=access_token,
-                accept="application/json",
-                content_type="application/json",
-            )
-
-            # TODO: Consider using the `params` argument of `requests.get` to handle building the
-            #       URL's query string. That way, we would be delegating the responsibility of
-            #       encoding query parameters, to the `requests` library.
-            #       Reference: https://requests.readthedocs.io/en/latest/user/quickstart/#passing-parameters-in-urls
-            #
-            url = f"{url_prefix}?filter={filter}&max_page_size={max_page_size}&projection={fields}&page_token={next_page_token}"
-            try:
-                response = requests.get(url, headers=headers)
-                response.raise_for_status()
-            except requests.exceptions.RequestException as e:
-                logger.error("API request failed", exc_info=True)
-                raise RuntimeError("Failed to get collection from NMDC API") from e
-            else:
-                logging.debug(
-                    f"API request response: {response.json()}\n API Status Code: {response.status_code}"
-                )
-            results = {"resources": results["resources"] + response.json()["resources"]}
-        return results
 
     def get_linked_instances(
         self,


### PR DESCRIPTION
Closes #141 

Refactored the inheritance hierarchy to cleanly separate public read-only search classes from privileged (auth-required) classes. Both now inherit from a common `NMDCAPIClient` base class, but privileged classes no longer inherit search utility methods.

Now all public-facing API functionality is under the `NMDCSearch` class which I think is much more user-friendly, maintainable, and documentable.

## Changes

### Old Inheritance Structure

```
NMDCSearch (HTTP methods + search utilities)
    │
    ├── CollectionSearch → BiosampleSearch, StudySearch, DataObjectSearch, etc.
    │
    ├── NMDCAuth, Minter, Metadata, JGI*API, GlobusTaskAPI
    │   (inherited search methods they didn't need)
    │
    └──FunctionalSearch → FunctionalAnnotationAggSearch
```

### New Inheritance Structure

```
NMDCAPIClient (HTTP methods)
    │
    ├── NMDCSearch (search utilities only)
    │   │
    │   └── CollectionSearch
    │           │
    │           └── BiosampleSearch, StudySearch, DataObjectSearch, FunctionalSearch, etc.
    │               (public read-only search API)
    │
    └── Privileged Classes
        ├── NMDCAuth
        ├── Minter
        ├── Metadata
        ├── JGISequencingProjectAPI
        ├── JGISampleSearchAPI
        └── GlobusTaskAPI
```
## Technical Details

### What Moved

**From `NMDCSearch` to `NMDCAPIClient`:**
- `__init__()` - Constructor including handling of base URL
- `_build_http_request_headers()` - HTTP header construction
- `_get_all_pages()` - Pagination helper

**Inheritance Changes:**
- `NMDCAuth`: `NMDCSearch` → `NMDCAPIClient`
- `Minter`: `NMDCSearch` → `NMDCAPIClient`
- `Metadata`: `NMDCSearch` → `NMDCAPIClient`
- `JGISequencingProjectAPI`: `NMDCSearch` → `NMDCAPIClient`
- `JGISampleSearchAPI`: `NMDCSearch` → `NMDCAPIClient`
- `GlobusTaskAPI`: `NMDCSearch` → `NMDCAPIClient`
- `FunctionalSearch`: No base class  → `CollectionSearch` 

### Additional handling for id-based operations
With new inheritance for `FunctionalSearch`(`CollectionSearch`), I added a handling method for the methods on `CollectionSearch` that cannot be used on `FunctionalSearch` due to lack of ids in the functional_aggregation_set.

### What Stayed the Same

- `NMDCSearch` still provides search utilities: `get_linked_instances()`, `get_records_by_id()`, `get_collection_name_from_id()`, etc.
- `CollectionSearch` and all collection-specific search classes remain unchanged
- All public APIs remain backwards compatible
- No changes to tests or external usage