### PR TITLE
Allow GHA-based `pytest` to discover tests outside of `test/` directory

### DIFF
--- a/.github/workflows/dev_tests.yml
+++ b/.github/workflows/dev_tests.yml
@@ -36,7 +36,8 @@ jobs:
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           API_BASE_URL: "https://api-dev.microbiomedata.org"  # dev
-        run: pytest -x nmdc_api_utilities/test/
+        # Note: Our baseline pytest CLI options are in the `[tool.pytest]` section of `pyproject.toml`.
+        run: pytest -x nmdc_api_utilities/
       - name: Create Issue
         if: failure() && github.event.pull_request == null && github.event_name == 'schedule'
         uses: actions/github-script@v6

--- a/.github/workflows/prod_tests.yml
+++ b/.github/workflows/prod_tests.yml
@@ -36,7 +36,8 @@ jobs:
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           API_BASE_URL : "https://api.microbiomedata.org"  # prod
-        run: pytest -x nmdc_api_utilities/test/
+        # Note: Our baseline pytest CLI options are in the `[tool.pytest]` section of `pyproject.toml`.
+        run: pytest -x nmdc_api_utilities/
       - name: Create Issue
         if: failure() && github.event.pull_request == null && github.event_name == 'schedule'
         uses: actions/github-script@v6


### PR DESCRIPTION
On this branch, I updated the `prod tests` (`prod_tests.yml`) and `dev tests` (`dev_tests.yml`) GHA workflows so that, when they invoke `pytest`, `pytest` finds tests residing _anywhere_ within the package root (instead of only within `{package_root}/test`). Since we automatically include the `--doctest-modules` option (according to `pyproject.toml`), that includes any doctests residing in regular, "non-test" modules (as shown in the screenshot below).

<img width="700" height="582" alt="image" src="https://github.com/user-attachments/assets/e3115312-6afc-456a-a4ed-64260fbcc76f" />

Props to @kheal for checking whether the doctests were running on GHA!

Fixes #159