### PR TITLE
Refrain from including `max_page_size` query parameter ignored by API endpoint

### DIFF
--- a/nmdc_api_utilities/data_object_search.py
+++ b/nmdc_api_utilities/data_object_search.py
@@ -22,6 +22,10 @@ class DataObjectSearch(CollectionSearch):
             env=env,
         )
 
+    def get_data_objects_for_studies(self, study_id: str) -> list[dict]:
+        """(Deprecated) This method is deprecated. Use `get_data_objects_for_study` instead."""
+        return self.get_data_objects_for_study(study_id)
+
     def get_data_objects_for_study(self, study_id: str) -> list[dict]:
         """
         Get all data objects related to the specified study.

--- a/nmdc_api_utilities/data_object_search.py
+++ b/nmdc_api_utilities/data_object_search.py
@@ -24,7 +24,7 @@ class DataObjectSearch(CollectionSearch):
 
     def get_data_objects_for_study(self, study_id: str) -> list[dict]:
         """
-        Gets all data objects related to all biosamples associated with the specified study.
+        Get all data objects related to the specified study.
 
         Parameters
         ----------

--- a/nmdc_api_utilities/data_object_search.py
+++ b/nmdc_api_utilities/data_object_search.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
 import logging
-from typing import Optional
 import warnings
+from typing import Optional
 
 import requests
 

--- a/nmdc_api_utilities/data_object_search.py
+++ b/nmdc_api_utilities/data_object_search.py
@@ -39,13 +39,18 @@ class DataObjectSearch(CollectionSearch):
             category=DeprecationWarning,
             stacklevel=2,
         )
-        return self.get_data_objects_for_study(study_id, max_page_size)
 
-    def get_data_objects_for_study(
-        self,
-        study_id: str,
-        max_page_size: Optional[int] = None,
-    ) -> list[dict]:
+        if max_page_size is not None:
+            warnings.warn(
+                "The `max_page_size` parameter is deprecated and will be removed in "
+                "a future release. It has no effect.",
+                category=DeprecationWarning,
+                stacklevel=2,
+            )
+
+        return self.get_data_objects_for_study(study_id)
+
+    def get_data_objects_for_study(self, study_id: str) -> list[dict]:
         """
         Get all data objects related to the specified study.
 
@@ -53,8 +58,6 @@ class DataObjectSearch(CollectionSearch):
         ----------
         study_id: str
             The ID of the study.
-        max_page_size: Optional[int]
-            (Deprecated) This parameter has no effect.
         Returns
         -------
         list[dict]
@@ -64,13 +67,6 @@ class DataObjectSearch(CollectionSearch):
         RuntimeError
             If the API request fails.
         """
-
-        if max_page_size is not None:
-            warnings.warn(
-                "The `max_page_size` parameter is deprecated and will be removed in a future release.",
-                category=DeprecationWarning,
-                stacklevel=2,
-            )
 
         url = f"{self.api_base_url}/data_objects/study/{study_id}"
         try:

--- a/nmdc_api_utilities/data_object_search.py
+++ b/nmdc_api_utilities/data_object_search.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 
 import logging
+from typing import Optional
+import warnings
 
 import requests
 
@@ -22,11 +24,28 @@ class DataObjectSearch(CollectionSearch):
             env=env,
         )
 
-    def get_data_objects_for_studies(self, study_id: str) -> list[dict]:
-        """(Deprecated) This method is deprecated. Use `get_data_objects_for_study` instead."""
-        return self.get_data_objects_for_study(study_id)
+    def get_data_objects_for_studies(
+        self,
+        study_id: str,
+        max_page_size: Optional[int] = None,
+    ) -> list[dict]:
+        """
+        (Deprecated) This method is deprecated. Use `get_data_objects_for_study` instead.
+        """
 
-    def get_data_objects_for_study(self, study_id: str) -> list[dict]:
+        warnings.warn(
+            "The `get_data_objects_for_studies` method is deprecated and will be removed in "
+            "a future release. Use the `get_data_objects_for_study` method instead.",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.get_data_objects_for_study(study_id, max_page_size)
+
+    def get_data_objects_for_study(
+        self,
+        study_id: str,
+        max_page_size: Optional[int] = None,
+    ) -> list[dict]:
         """
         Get all data objects related to the specified study.
 
@@ -34,6 +53,8 @@ class DataObjectSearch(CollectionSearch):
         ----------
         study_id: str
             The ID of the study.
+        max_page_size: Optional[int]
+            (Deprecated) This parameter has no effect.
         Returns
         -------
         list[dict]
@@ -43,6 +64,14 @@ class DataObjectSearch(CollectionSearch):
         RuntimeError
             If the API request fails.
         """
+
+        if max_page_size is not None:
+            warnings.warn(
+                "The `max_page_size` parameter is deprecated and will be removed in a future release.",
+                category=DeprecationWarning,
+                stacklevel=2,
+            )
+
         url = f"{self.api_base_url}/data_objects/study/{study_id}"
         try:
             response = requests.get(

--- a/nmdc_api_utilities/data_object_search.py
+++ b/nmdc_api_utilities/data_object_search.py
@@ -22,27 +22,24 @@ class DataObjectSearch(CollectionSearch):
             env=env,
         )
 
-    def get_data_objects_for_studies(
-        self, study_id: str, max_page_size: int = 100
-    ) -> list[dict]:
+    def get_data_objects_for_study(self, study_id: str) -> list[dict]:
         """
-        Get data objects by study id.
+        Gets all data objects related to all biosamples associated with the specified study.
+
         Parameters
         ----------
         study_id: str
-            The study id to search for.
-        max_page_size: int
-            The maximum number of items to return per page. Default is 100
+            The ID of the study.
         Returns
         -------
         list[dict]
-            A list of data objects.
+            The data objects.
         Raises
         ------
         RuntimeError
             If the API request fails.
         """
-        url = f"{self.api_base_url}/data_objects/study/{study_id}?max_page_size={max_page_size}"
+        url = f"{self.api_base_url}/data_objects/study/{study_id}"
         try:
             response = requests.get(
                 url,

--- a/nmdc_api_utilities/nmdc_search.py
+++ b/nmdc_api_utilities/nmdc_search.py
@@ -26,9 +26,17 @@ class NMDCSearch:
 
     def __init__(self, api_base_url: str = API_BASE_URL, env: str = ""):
         if env != "":
-            # Note: `stacklevel=2` makes it so the displayed warning focuses on the function call
-            #       that _used_ the deprecated parameter (since that is where action is required)
-            #       rather than focusing on this call of `warnings.warn`, itself.
+            # Note: Although we could have used `stacklevel=3` here (which would have made it so that,
+            #       when the user instantiates this class via an inheriting class, the warning shown
+            #       by Python would show the line of code where the user instantiated the inheriting
+            #       class, which we think would be most useful to that user) we have opted to use
+            #       `stacklevel=2` here, since this class can _also_ be instantiated directly and,
+            #       if we were to use `stacklevel=3`, Python wouldn't even _show_ a warning for those
+            #       direct instantiations. Using `stacklevel=2` is a compromise that ensures that
+            #       Python _does_ show a warning in both situations, although the line of code shown
+            #       in the warning message may not always be code controlled by the user.
+            #       Docs: https://docs.python.org/3/library/warnings.html#warnings.deprecated
+            #
             warnings.warn(
                 "`env` is deprecated and will be removed in a future release. "
                 "Use `api_base_url` instead.",

--- a/nmdc_api_utilities/nmdc_search.py
+++ b/nmdc_api_utilities/nmdc_search.py
@@ -26,10 +26,14 @@ class NMDCSearch:
 
     def __init__(self, api_base_url: str = API_BASE_URL, env: str = ""):
         if env != "":
+            # Note: `stacklevel=2` makes it so the displayed warning focuses on the function call
+            #       that _used_ the deprecated parameter (since that is where action is required)
+            #       rather than focusing on this call of `warnings.warn`, itself.
             warnings.warn(
                 "`env` is deprecated and will be removed in a future release. "
                 "Use `api_base_url` instead.",
-                DeprecationWarning,
+                category=DeprecationWarning,
+                stacklevel=2,
             )
         self.api_base_url = get_api_base_url(api_base_url=api_base_url, env=env)
 

--- a/nmdc_api_utilities/test/test_data_object.py
+++ b/nmdc_api_utilities/test/test_data_object.py
@@ -19,3 +19,17 @@ def test_get_data_objects_for_study():
     assert results
     assert len(results) > 0
     assert "data_objects" in results[0]
+
+
+def test_get_data_objects_for_studies():
+    """
+    Test the (deprecated) get_data_objects_for_studies (plural) method.
+    """
+    do_search = DataObjectSearch(api_base_url=API_BASE_URL)
+
+    study_id = "nmdc:sty-11-aygzgv51"
+    results = do_search.get_data_objects_for_studies(study_id)
+    logging.debug(f"Results: {results}")
+    assert results
+    assert len(results) > 0
+    assert "data_objects" in results[0]

--- a/nmdc_api_utilities/test/test_data_object.py
+++ b/nmdc_api_utilities/test/test_data_object.py
@@ -7,14 +7,14 @@ from nmdc_api_utilities.data_object_search import DataObjectSearch
 logging.basicConfig(level=logging.DEBUG)
 
 
-def test_get_do_by_study():
+def test_get_data_objects_for_study():
     """
-    Test the get_data_objects_for_studies method.
+    Test the get_data_objects_for_study method.
     """
     do_search = DataObjectSearch(api_base_url=API_BASE_URL)
 
     study_id = "nmdc:sty-11-aygzgv51"
-    results = do_search.get_data_objects_for_studies(study_id)
+    results = do_search.get_data_objects_for_study(study_id)
     logging.debug(f"Results: {results}")
     assert results
     assert len(results) > 0


### PR DESCRIPTION
On this branch, I updated an HTTP request sent by this library so that it would **not** include a query parameter named `max_page_size`, which is ignored by [the receiving API endpoint](https://api-dev.microbiomedata.org/docs#/Metadata%20access/Find_data_objects_for_study__delayed__data_objects_study__study_id__get). I also made it so Python shows a warning when the associated kwarg is used.

I also renamed the method to say `study` instead of `studies` (to be consistent with the endpoint's behavior). Then, I added a deprecated "pass-through" method having the original "interface" so as to preserve backwards compatibility.

Finally, I added the `stacklevel=2` kwarg to the `warnings.warn` calls that we currently use for deprecation, so that the warnings displayed by Python show the _calling_ code (where action is required) instead of our calls of `warnings.warn`.

Side note: Eventually, I'd like to introduce the https://pypi.org/project/Deprecated/ package to standardize how we deprecate things, but not right now because we have at least 3 PRs in flight, some of which touch lots of files. Python 3.13 introduced a new annotation related to deprecation, but this library supports older Python versions, so I don't plan to use that annotation.