### PR TITLE
Introduce `mypy` as a static type checker

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,21 +58,23 @@ repos:
         args: ["--select", "I", "--fix"]  # Automatically fix import formatting
         additional_dependencies: []
 
-  # This pre-commit hook runs mypy to perform static type checking.
+  # This pre-commit hook performs static type checking by running mypy.
   #
-  # Note: We use `bash -c '... || true'` to guarantee the overall command returns true,
-  #       effectively making this a _non-blocking_ hook. This allows developers to see
-  #       mypy's output, without requiring them to ensure error-free output. We may convert
-  #       this into a blocking hook later, after resolving all existing violations.
+  # Note: We use `bash -c 'mypy || true'` to guarantee the overall command returns a zero status,
+  #       effectively making this a _non-blocking_ hook. This allows developers to see mypy's
+  #       output, without requiring them to ensure error-free output. We may convert this into a
+  #       blocking hook later, after resolving all existing violations.
   #
   - repo: local
     hooks:
       - id: mypy
         name: mypy
-        entry: bash -c './.venv/bin/mypy || true'  # non-blocking
+        entry: bash -c 'mypy || true'  # non-blocking
         language: python
         types: [python]
-        verbose: true  # show mypy's output
+        pass_filenames: false  # avoid redundant args (mypy will use the config in `pyproject.toml`)
+        verbose: true  # show the hook's output even when the hook always returns a zero status
+        additional_dependencies: [mypy]
 
   # - repo: https://github.com/thclark/pre-commit-sphinx
   #   rev: 0.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,15 +60,15 @@ repos:
 
   # This pre-commit hook performs static type checking by running mypy.
   #
-  # Note: We use `bash -c 'mypy || true'` to guarantee the overall command returns a 0 exit code,
+  # Note: We use `sh -c 'mypy || true'` to guarantee the overall command returns a 0 exit code,
   #       effectively making this a _non-blocking_ hook. This allows developers to see mypy's
   #       output, without requiring them to ensure the output is error-free. We may convert this
   #       into a blocking hook later, after resolving all existing violations.
   #
   # TODO: Figure out a way to keep the `additional_dependencies` package list (names and versions)
   #       in sync with `requirements.txt` and `requirements-dev.txt` automatically. We could use
-  #       `language: system` for that, but that would require developers to run `git commit` in a
-  #       an environment that has all the dependencies already installed (which might be OK for us).
+  #       `language: system` for that, but that would require developers to run `git commit` in an
+  #       environment that has all the dependencies already installed (which might be OK for us).
   #
   - repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,21 +60,30 @@ repos:
 
   # This pre-commit hook performs static type checking by running mypy.
   #
-  # Note: We use `bash -c 'mypy || true'` to guarantee the overall command returns a zero status,
+  # Note: We use `bash -c 'mypy || true'` to guarantee the overall command returns a 0 exit code,
   #       effectively making this a _non-blocking_ hook. This allows developers to see mypy's
-  #       output, without requiring them to ensure error-free output. We may convert this into a
-  #       blocking hook later, after resolving all existing violations.
+  #       output, without requiring them to ensure the output is error-free. We may convert this
+  #       into a blocking hook later, after resolving all existing violations.
+  #
+  # TODO: Figure out a way to keep the `additional_dependencies` package list (names and versions)
+  #       in sync with `requirements.txt` and `requirements-dev.txt` automatically. We could use
+  #       `language: system` for that, but that would require developers to run `git commit` in a
+  #       an environment that has all the dependencies already installed (which might be OK for us).
   #
   - repo: local
     hooks:
       - id: mypy
         name: mypy
-        entry: bash -c 'mypy || true'  # non-blocking
+        entry: sh -c 'mypy || true'  # always returns a 0 exit code (making this hook non-blocking)
         language: python
         types: [python]
-        pass_filenames: false  # avoid redundant args (mypy will use the config in `pyproject.toml`)
-        verbose: true  # show the hook's output even when the hook always returns a zero status
-        additional_dependencies: [mypy]
+        pass_filenames: false  # avoid redundant args to mypy (see mypy config in `pyproject.toml`)
+        verbose: true  # show the hook's output in all circumstances (regardless of exit code)
+        additional_dependencies:
+          - mypy==1.20.2
+          - types-requests==2.33.0.20260408
+          - pandas-stubs==3.0.0.260204
+          - matplotlib==3.10.8
 
   # - repo: https://github.com/thclark/pre-commit-sphinx
   #   rev: 0.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,7 +63,7 @@ repos:
   # Note: We use `sh -c 'mypy || true'` to guarantee the overall command returns a 0 exit code,
   #       effectively making this a _non-blocking_ hook. This allows developers to see mypy's
   #       output, without requiring them to ensure the output is error-free. We may convert this
-  #       into a blocking hook later, after resolving all existing violations.
+  #       into a blocking hook later, after developers have formed opinions about mypy over time.
   #
   # TODO: Figure out a way to keep the `additional_dependencies` package list (names and versions)
   #       in sync with `requirements.txt` and `requirements-dev.txt` automatically. We could use

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,6 +58,22 @@ repos:
         args: ["--select", "I", "--fix"]  # Automatically fix import formatting
         additional_dependencies: []
 
+  # This pre-commit hook runs mypy to perform static type checking.
+  #
+  # Note: We use `bash -c '... || true'` to guarantee the overall command returns true,
+  #       effectively making this a _non-blocking_ hook. This allows developers to see
+  #       mypy's output, without requiring them to ensure error-free output. We may convert
+  #       this into a blocking hook later, after resolving all existing violations.
+  #
+  - repo: local
+    hooks:
+      - id: mypy
+        name: mypy
+        entry: bash -c './.venv/bin/mypy || true'  # non-blocking
+        language: python
+        types: [python]
+        verbose: true  # show mypy's output
+
   # - repo: https://github.com/thclark/pre-commit-sphinx
   #   rev: 0.0.1
   #   hooks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,20 +110,21 @@ This project uses pip paired with venv to manage dependencies. Note that require
 ### Static type checking
 
 We use [mypy](https://mypy-lang.org/) to validate our code in terms of data types.
-Because mypy is a _static_ type checker, we can use it to find problems without running the code. For example, mypy will detect and report inconsistencies like the following:
+Because mypy is a _static_ type checker, we can use it to find problems without running the code.
+For example, mypy will report inconsistencies like the following:
 
 ```py
-# Inconsistency: Return type `bool` doesn't account for value `None`.
-def is_large(num: int) -> bool:
-    if num > 10:
-        return True
+def triple(n: int) -> int:
+    return n * 3
+
+greet("1")  # 🙋 mypy will report this inconsistency
 ```
 
 #### Perform static type checking
 
 You can perform static type checking by running:
 
-```py
+```sh
 mypy
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,6 +107,28 @@ This project uses pip paired with venv to manage dependencies. Note that require
 
     `pre-commit install`
 
+### Static type checking
+
+We use [mypy](https://mypy-lang.org/) to validate our code in terms of data types.
+Because mypy is a _static_ type checker, we can use it to find problems without running the code. For example, mypy will detect and report inconsistencies like the following:
+
+```py
+# Inconsistency: Return type `bool` doesn't account for value `None`.
+def is_large(num: int) -> bool:
+    if num > 10:
+        return True
+```
+
+#### Perform static type checking
+
+You can perform static type checking by running:
+
+```py
+mypy
+```
+
+By default, mypy will use the configuration specified within the `[tool.mypy]` section of `pyproject.toml`. You can override aspects of that configuration via [CLI options](https://mypy.readthedocs.io/en/stable/command_line.html).
+
 ### Previewing user documentation
 
 We use [Sphinx](https://www.sphinx-doc.org/en/master/) to generate user documentation. Our Sphinx

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,7 +117,7 @@ For example, mypy will report inconsistencies like the following:
 def triple(n: int) -> int:
     return n * 3
 
-greet("1")  # 🙋 mypy will report this inconsistency
+triple("1")  # 🙋 mypy will report this inconsistency
 ```
 
 #### Perform static type checking

--- a/nmdc_api_utilities/auth.py
+++ b/nmdc_api_utilities/auth.py
@@ -65,10 +65,12 @@ class NMDCAuth(NMDCAPIClient):
         self._token: str | None = None
         self._token_expires_at: datetime | None = None
         self._oauth_session: Any | None = None
-        self.grant_type = (
+        self.grant_type: str | None = (
             "client_credentials"
             if (self.client_id and self.client_secret)
             else "password"
+            if (self.username and self.password)
+            else None
         )
 
     def has_credentials(self) -> bool:

--- a/nmdc_api_utilities/auth.py
+++ b/nmdc_api_utilities/auth.py
@@ -2,6 +2,7 @@
 
 import logging
 from datetime import datetime, timedelta
+from typing import Any
 
 import requests
 
@@ -46,10 +47,10 @@ class NMDCAuth(NMDCAPIClient):
 
     def __init__(
         self,
-        client_id: str = None,
-        client_secret: str = None,
-        username: str = None,
-        password: str = None,
+        client_id: str | None = None,
+        client_secret: str | None = None,
+        username: str | None = None,
+        password: str | None = None,
         api_base_url: str = API_BASE_URL,
         env: str = "",
     ):
@@ -61,9 +62,9 @@ class NMDCAuth(NMDCAPIClient):
         self.client_secret = client_secret
         self.username = username
         self.password = password
-        self._token = None
-        self._token_expires_at = None
-        self._oauth_session = None
+        self._token: str | None = None
+        self._token_expires_at: datetime | None = None
+        self._oauth_session: Any | None = None
         self.grant_type = (
             "client_credentials"
             if (self.client_id and self.client_secret)
@@ -81,6 +82,7 @@ class NMDCAuth(NMDCAPIClient):
     def get_token(self) -> str:
         """Get a valid access token, refreshing if necessary."""
         if self._is_token_valid():
+            assert isinstance(self._token, str)  # to appease mypy
             return self._token
         return self._refresh_token()
 
@@ -104,9 +106,10 @@ class NMDCAuth(NMDCAPIClient):
                 "username": self.username,
                 "password": self.password,
             }
-
-        # TODO: If `self.grant_type` is neither "client_credentials" nor "password",
-        #       `token_request_body` below will be unbound. Handle that situation.
+        else:
+            raise ValueError(
+                "Refreshing a token requires that credentials be specified."
+            )
 
         response = requests.post(
             f"{self.api_base_url}/token",
@@ -133,4 +136,5 @@ class NMDCAuth(NMDCAPIClient):
             self._token_expires_at = (
                 datetime.now() + expires_delta - timedelta(seconds=60)
             )
+        assert isinstance(self._token, str)  # to appease mypy
         return self._token

--- a/nmdc_api_utilities/biosample_search.py
+++ b/nmdc_api_utilities/biosample_search.py
@@ -8,7 +8,15 @@ from nmdc_api_utilities.lat_long_filters import LatLongFilters
 logger = logging.getLogger(__name__)
 
 
-class BiosampleSearch(LatLongFilters, CollectionSearch):
+# Note: We specify the `CollectionSearch` class before the `LatLongFilters` class so that the
+#       `BiosampleSearch` class uses the _concrete_ `get_records` method from the `CollectionSearch`
+#       class (which is specified first) instead of the _abstract_ `get_records` method from the
+#       `LatLongFilters` (which is specified later). An alternative would be to implement a concrete
+#       "pass-through" method (here in `BiosampleSearch`) that, itself, explicitly invokes
+#       `CollectionSearch.get_records(self, filter, max_page_size, fields, all_pages)`.
+#       Docs: https://realpython.com/ref/glossary/mro/
+#
+class BiosampleSearch(CollectionSearch, LatLongFilters):
     """
     Class to interact with the NMDC API to search for records within the ``biosample_set`` collection.
     """

--- a/nmdc_api_utilities/collection_search.py
+++ b/nmdc_api_utilities/collection_search.py
@@ -227,8 +227,11 @@ class CollectionSearch(NMDCSearch):
         return results
 
     def check_ids_exist(
-        self, ids: list, chunk_size: int = 100, return_missing_ids: bool = False
-    ) -> bool:
+        self,
+        ids: list[str],
+        chunk_size: int = 100,
+        return_missing_ids: bool = False,
+    ) -> bool | tuple[bool, list[str]]:
         """
         Check if specified IDs exist in the collection.
 
@@ -245,9 +248,10 @@ class CollectionSearch(NMDCSearch):
 
         Returns
         -------
-        bool
-            True if all IDs exist in the collection, False otherwise.
-
+        bool | tuple[bool, list[str]]
+            True if all IDs exist in the collection, False otherwise. However,
+            if return_missing_ids is True, returns a tuple whose first item is the aforementioned boolean value,
+            and whose second item is a list of the IDs, if any, that don't exist in the collection.
         """
         if not getattr(self, "supports_get_by_id", True):
             raise OperationNotSupportedError(
@@ -310,8 +314,8 @@ class CollectionSearch(NMDCSearch):
         id_list = list(set(id_list))
         chunks = dp.split_list(input_list=id_list, chunk_size=chunk_size)
         for chunk in chunks:
-            chunk = dp._string_mongo_list(data=chunk)
-            filter = f'{{"{search_field}": {{"$in": {chunk}}}}}'
+            sanitized_chunk = dp._string_mongo_list(data=chunk)
+            filter = f'{{"{search_field}": {{"$in": {sanitized_chunk}}}}}'
             res = self.get_records(
                 filter=filter, max_page_size=len(chunk), fields=fields, all_pages=True
             )

--- a/nmdc_api_utilities/config.py
+++ b/nmdc_api_utilities/config.py
@@ -5,11 +5,6 @@ This module contains the definitions of variables used throughout the package.
 
 import os
 import re
-from typing import Literal
-
-# (Deprecated) Name of the environment hosting an instance of the NMDC Runtime API.
-EnvName = Literal["dev", "prod", ""]
-
 
 # Base URL of the production instance of the NMDC Runtime API.
 PRODUCTION_API_BASE_URL = "https://api.microbiomedata.org"
@@ -32,7 +27,7 @@ def _sanitize_api_base_url(api_base_url: str) -> str:
     raise ValueError(f"Invalid API base URL: {api_base_url}")
 
 
-def get_api_base_url(api_base_url: str = PRODUCTION_API_BASE_URL, env: EnvName = ""):
+def get_api_base_url(api_base_url: str = PRODUCTION_API_BASE_URL, env: str = "") -> str:
     """
     Get the base URL of the NMDC Runtime API to use for API requests, based upon the specified
     API base URL and environment nickname (each oftentimes obtained from an environment variable).

--- a/nmdc_api_utilities/data_processing.py
+++ b/nmdc_api_utilities/data_processing.py
@@ -27,6 +27,12 @@ class DataProcessing:
         """
         # TODO: The docstring contradicts (a) the type hint and (b) some invocations of this method
         #       within this library, itself (they pass it a dictionary instead of a list).
+        #
+        # TODO: Add doctests demonstrating how this would treat an input list containing dictionaries
+        #       whose values contain single quotes (not as delimiters); e.g. { lastName: "O'Connor" }.
+        #       In general, consider using a standard serialization pipeline (e.g. dict -> json -> str)
+        #       instead of an ad hoc one so corner cases are covered.
+        #
         return str(data).replace("'", '"')
 
     def convert_to_df(self, data: list[dict[str, Any]]) -> pd.DataFrame:
@@ -178,9 +184,8 @@ class DataProcessing:
             Under the hood this is used to determine if the inputted attribute value should be wrapped in a regex expression.
         Returns
         -------
-        dict
-            A dictionary representing the MongoDB filter.
-            Example: {"name": {"$regex": "example", "$options": "i"}, "description": {"$regex": "example", "$options": "i"}}
+        str
+            A string representing the MongoDB filter.
         """
         filter_dict: dict[str, str | dict[str, str]] = {}
         if exact_match:

--- a/nmdc_api_utilities/data_processing.py
+++ b/nmdc_api_utilities/data_processing.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import logging
 import re
+from typing import Any
 
 import pandas as pd
 
@@ -11,7 +12,7 @@ class DataProcessing:
     def __init__(self):
         pass
 
-    def _string_mongo_list(self, data: list) -> str:
+    def _string_mongo_list(self, data: list[Any] | dict[str, Any]) -> str:
         """
         Convert elements in a list to use double quotes instead of single quotes.
         This is required for mongo queries.
@@ -24,9 +25,11 @@ class DataProcessing:
         str
             A string representation of the list with double quotes.
         """
+        # TODO: The docstring contradicts (a) the type hint and (b) some invocations of this method
+        #       within this library, itself (they pass it a dictionary instead of a list).
         return str(data).replace("'", '"')
 
-    def convert_to_df(self, data: list) -> pd.DataFrame:
+    def convert_to_df(self, data: list[dict[str, Any]]) -> pd.DataFrame:
         """
         Convert a list of dictionaries to a pandas dataframe.
 
@@ -42,7 +45,9 @@ class DataProcessing:
         """
         return pd.DataFrame(data)
 
-    def split_list(self, input_list: list, chunk_size: int = 100) -> list:
+    def split_list(
+        self, input_list: list[Any], chunk_size: int = 100
+    ) -> list[list[Any]]:
         """
         Split a list into chunks of a specified size.
 
@@ -63,7 +68,9 @@ class DataProcessing:
 
         return result
 
-    def rename_columns(self, df: pd.DataFrame, new_col_names: list) -> pd.DataFrame:
+    def rename_columns(
+        self, df: pd.DataFrame, new_col_names: list[str]
+    ) -> pd.DataFrame:
         """
         Rename columns in a pandas dataframe.
 
@@ -155,7 +162,9 @@ class DataProcessing:
         merged_df.drop_duplicates(keep="first", inplace=True)
         return merged_df
 
-    def build_filter(self, attributes: dict, exact_match: bool = False) -> dict:
+    def build_filter(
+        self, attributes: dict[str, str], exact_match: bool = False
+    ) -> str:
         """
         Create a MongoDB filter using $regex for each attribute in the input dictionary. For nested attributes, use dot notation.
 
@@ -173,7 +182,7 @@ class DataProcessing:
             A dictionary representing the MongoDB filter.
             Example: {"name": {"$regex": "example", "$options": "i"}, "description": {"$regex": "example", "$options": "i"}}
         """
-        filter_dict = {}
+        filter_dict: dict[str, str | dict[str, str]] = {}
         if exact_match:
             for attribute_name, attribute_value in attributes.items():
                 filter_dict[attribute_name] = attribute_value
@@ -185,11 +194,17 @@ class DataProcessing:
                 logging.debug(f"Attribute name: {attribute_name}")
                 filter_dict[attribute_name] = {"$regex": escaped_value, "$options": "i"}
                 logging.debug(f"Filter dict: {filter_dict}")
+
+        # TODO: The value being passed to `_string_mongo_list` below might be a dictionary whose
+        #       values are string, and it might be a dictionary whose values are, themselves,
+        #       dictionaries. The method's docstring says it expects to be passed a LIST.
         clean = self._string_mongo_list(filter_dict)
         logging.debug(f"Filter cleaned: {clean}")
         return clean
 
-    def extract_field(self, api_results: list, field_name: str) -> list:
+    def extract_field(
+        self, api_results: list[dict[str, Any]], field_name: str
+    ) -> list[Any]:
         """
         Extract a specific field's values from records retrieved via the NMDC API.
 
@@ -205,11 +220,11 @@ class DataProcessing:
         list
             A list of values for the specified field.
         """
-        field_list = []
+        field_list: list[Any] = []
         for item in api_results:
-            if type(item[field_name]) == str:
+            if isinstance(item[field_name], str):
                 field_list.append(item[field_name])
-            elif type(item[field_name]) == list:
+            elif isinstance(item[field_name], list):
                 for another_item in item[field_name]:
                     field_list.append(another_item)
         return field_list

--- a/nmdc_api_utilities/data_staging.py
+++ b/nmdc_api_utilities/data_staging.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import json
 import logging
+from typing import Any
 
 import requests
 
@@ -86,11 +87,11 @@ class JGISequencingProjectAPI(NMDCAPIClient):
     @requires_auth
     def list_jgi_sequencing_projects(
         self,
-        filter: str = None,
+        filter: str | None = None,
         max_page_size: int = 20,
         fields: str = "",
         all_pages: bool = False,
-    ) -> dict:
+    ) -> list[dict[str, Any]]:
         """
         List JGI sequencing projects from the NMDC database.
 
@@ -107,7 +108,7 @@ class JGISequencingProjectAPI(NMDCAPIClient):
 
         Returns
         -------
-        dict
+        list
             The list of JGI sequencing projects.
         """
         url = f"{self.api_base_url}/wf_file_staging/jgi_sequencing_projects"
@@ -117,7 +118,9 @@ class JGISequencingProjectAPI(NMDCAPIClient):
             content_type="application/json",
         )
         try:
-            query_params = {
+            # Note: The `dict` is here to appease mypy, which, for some reason, doesn't infer that
+            #       the dictionary being assigned here is sufficient to pass to `requests.get`.
+            query_params: dict = {
                 "filter": f"{json.dumps(filter)}",
                 "max_page_size": max_page_size,
                 "projection": fields,
@@ -135,7 +138,7 @@ class JGISequencingProjectAPI(NMDCAPIClient):
             return self._get_all_pages(
                 response,
                 url,
-                filter,
+                filter or "",
                 max_page_size,
                 fields,
                 access_token=self.auth.get_token(),
@@ -206,7 +209,7 @@ class JGISampleSearchAPI(NMDCAPIClient):
     @requires_auth
     def list_jgi_samples(
         self,
-        filter: str = None,
+        filter: str | None = None,
         max_page_size: int = 20,
         fields: str = "",
         all_pages: bool = False,
@@ -233,7 +236,7 @@ class JGISampleSearchAPI(NMDCAPIClient):
         url = f"{self.api_base_url}/wf_file_staging/jgi_samples"
         try:
             query = filter if filter else {}
-            query_params = {
+            query_params: dict[str, str | int] = {
                 "filter": f"{json.dumps(query)}",
                 "max_page_size": max_page_size,
                 "projection": fields,
@@ -257,7 +260,7 @@ class JGISampleSearchAPI(NMDCAPIClient):
             return self._get_all_pages(
                 response,
                 url,
-                filter,
+                filter or "",
                 max_page_size,
                 fields,
                 self.auth.get_token(),
@@ -386,7 +389,7 @@ class GlobusTaskAPI(NMDCAPIClient):
     @requires_auth
     def list_globus_tasks(
         self,
-        filter: str = None,
+        filter: str | None = None,
         max_page_size: int = 20,
         fields: str = "",
         all_pages: bool = False,
@@ -416,7 +419,7 @@ class GlobusTaskAPI(NMDCAPIClient):
             accept="application/json",
             content_type="application/json",
         )
-        query_params = {
+        query_params: dict[str, str | int] = {
             "filter": f"{json.dumps(filter)}",
             "max_page_size": max_page_size,
             "projection": fields,
@@ -433,7 +436,12 @@ class GlobusTaskAPI(NMDCAPIClient):
             )
         if all_pages:
             return self._get_all_pages(
-                response, url, filter, max_page_size, fields, self.auth.get_token()
+                response,
+                url,
+                filter or "",
+                max_page_size,
+                fields,
+                self.auth.get_token(),
             )["resources"]
         return response.json()["resources"]
 

--- a/nmdc_api_utilities/lat_long_filters.py
+++ b/nmdc_api_utilities/lat_long_filters.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import logging
-from abc import ABC
+from abc import ABC, abstractmethod
 
 logger = logging.getLogger(__name__)
 
@@ -10,6 +10,16 @@ class LatLongFilters(ABC):
     Mixin class with methods to interact with collections that
     can be searched by latitude and longitude via the NMDC API.
     """
+
+    @abstractmethod
+    def get_records(
+        self,
+        filter: str = "",
+        max_page_size: int = 100,
+        fields: str = "",
+        all_pages: bool = False,
+    ) -> list[dict]:
+        """Retrieve records from a collection via the NMDC API."""
 
     def get_record_by_latitude(
         self, comparison: str, latitude: float, page_size=25, fields="", all_pages=False

--- a/nmdc_api_utilities/metadata.py
+++ b/nmdc_api_utilities/metadata.py
@@ -30,7 +30,7 @@ class Metadata(NMDCAPIClient):
     def __init__(
         self,
         api_base_url: str = API_BASE_URL,
-        auth: NMDCAuth = None,
+        auth: NMDCAuth | None = None,
         env: str = "",
     ):
         super().__init__(

--- a/nmdc_api_utilities/minter.py
+++ b/nmdc_api_utilities/minter.py
@@ -27,7 +27,7 @@ class Minter(NMDCAPIClient):
     def __init__(
         self,
         api_base_url: str = API_BASE_URL,
-        auth: NMDCAuth = None,
+        auth: NMDCAuth | None = None,
         env: str = "",
     ):
         super().__init__(
@@ -41,8 +41,8 @@ class Minter(NMDCAPIClient):
         self,
         nmdc_type: str,
         count: int = 1,
-        client_id: str = None,
-        client_secret: str = None,
+        client_id: str | None = None,
+        client_secret: str | None = None,
     ) -> str | list[str]:
         """
         Mint new identifier(s) for a specified type of record.

--- a/nmdc_api_utilities/nmdc_search.py
+++ b/nmdc_api_utilities/nmdc_search.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import logging
+from typing import Any
 
 import requests
 
@@ -25,11 +26,16 @@ class NMDCSearch(NMDCAPIClient):
     def __init__(self, api_base_url: str = API_BASE_URL, env: str = ""):
         super().__init__(api_base_url=api_base_url, env=env)
 
+    @staticmethod
+    def _normalize_ids(ids: list[str] | str) -> list[str]:
+        """Ensures the IDs are in a list, even if there is only one ID."""
+        return ids if isinstance(ids, list) else [ids]
+
     def get_linked_instances(
         self,
         ids: list[str] | str,
         hydrate: bool = False,
-        types: list[str] | str = None,
+        types: list[str] | str | None = None,
         max_page_size: int = 500,
     ) -> list[dict]:
         """
@@ -61,11 +67,16 @@ class NMDCSearch(NMDCAPIClient):
         """
         # highest number I could get to without a timeout
         batch_size = 250
-        batch_records = []
+        # Note: We normalize the `ids` value into a list, since the docstring says the caller can
+        #       pass it in as either a bare string _or_ a list of strings. If we didn't do this,
+        #       and the caller did pass in a bare string, the code below would iterate over the
+        #       individual characters of that string (strings are iterable in Python).
+        list_of_ids = NMDCSearch._normalize_ids(ids)
+        batch_records: list[dict[str, Any]] = []
         url = f"{self.api_base_url}/nmdcschema/linked_instances"
         # split the ids into batches
-        for i in range(0, len(ids), batch_size):
-            batch = ids[i : i + batch_size]
+        for i in range(0, len(list_of_ids), batch_size):
+            batch = list_of_ids[i : i + batch_size]
             params = {
                 "types": types,
                 "ids": batch,
@@ -106,7 +117,7 @@ class NMDCSearch(NMDCAPIClient):
     def get_linked_instances_and_associate_ids(
         self,
         ids: list[str] | str,
-        types: list[str] | str = None,
+        types: list[str] | str | None = None,
         hydrate: bool = False,
         max_page_size: int = 500,
     ) -> dict[str, list[str]]:
@@ -135,13 +146,13 @@ class NMDCSearch(NMDCAPIClient):
         Returns
         -------
         dict[str, list[str]]
-            A dictionary mapping each input id to a list of its linked instance records.
+            A dictionary mapping each input id to a list of the ids of its linked instance records.
         """
         # get the linked instances
         linked_instances = self.get_linked_instances(
             types=types, ids=ids, hydrate=hydrate, max_page_size=max_page_size
         )
-        association = {}
+        association: dict[str, list[str]] = {}
         # loop through the linked instances and build the association
         for record in linked_instances:
             study_id = record["id"]
@@ -218,10 +229,10 @@ class NMDCSearch(NMDCAPIClient):
             The record(s) data.
         """
 
-        resources = []
+        resources: list[dict[str, Any]] = []
         # sort the input ids
         sorted_ids = sorted(ids) if isinstance(ids, list) else [ids]
-        id_dict = {}
+        id_dict: dict[str, list[str]] = {}
         # group ids by their collection subset nmdc:sty, nmdc:bsm, etc
         for id in sorted_ids:
             cur_group = id.split("-")[0]

--- a/nmdc_api_utilities/visualize.py
+++ b/nmdc_api_utilities/visualize.py
@@ -14,7 +14,7 @@ def plot(
     y: str = "",
     xlabel: str = "",
     ylabel: str = "",
-):
+) -> None:
     if plot_type == "scatter":
         plt.scatter(data[x], data[y])
     elif plot_type == "box":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,4 +31,4 @@ addopts = ["--doctest-modules"]  # run doctests defined in _all_ modules (not on
 # Docs: https://mypy.readthedocs.io/en/stable/config_file.html#the-mypy-configuration-file
 [tool.mypy]
 packages = ["nmdc_api_utilities"]  # check the `nmdc_api_utilities` package
-exclude = ["^nmdc_api_utilities/test/"]  # ignore the `nmdc_api_utilities/test` directory
+exclude = "^nmdc_api_utilities/test/"  # ignore paths beginning with `nmdc_api_utilities/test/`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,3 +26,8 @@ dependencies = {file = ["requirements.txt"]}
 # Docs: https://docs.pytest.org/en/stable/reference/customize.html#pyproject-toml
 [tool.pytest]
 addopts = ["--doctest-modules"]  # run doctests defined in _all_ modules (not only `test_*` modules)
+
+# Configure mypy.
+# Docs: https://mypy.readthedocs.io/en/stable/config_file.html#the-mypy-configuration-file
+[tool.mypy]
+packages = ["nmdc_api_utilities"]  # run mypy against the `nmdc_api_utilities` package (not the `tests` package)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,4 +30,5 @@ addopts = ["--doctest-modules"]  # run doctests defined in _all_ modules (not on
 # Configure mypy.
 # Docs: https://mypy.readthedocs.io/en/stable/config_file.html#the-mypy-configuration-file
 [tool.mypy]
-packages = ["nmdc_api_utilities"]  # run mypy against the `nmdc_api_utilities` package (not the `tests` package)
+packages = ["nmdc_api_utilities"]  # check the `nmdc_api_utilities` package
+exclude = ["^nmdc_api_utilities/test/"]  # ignore the `nmdc_api_utilities/test` directory

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,6 @@ sphinx_rtd_theme==3.1.0
 pytest==9.0.3
 build==1.4.3
 twine==6.2.0
+# We use mypy to validate our code in terms of data types.
+# Homepage: https://mypy-lang.org/
+mypy==1.20.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,12 @@ sphinx_rtd_theme==3.1.0
 pytest==9.0.3
 build==1.4.3
 twine==6.2.0
-# We use mypy to validate our code in terms of data types.
-# Homepage: https://mypy-lang.org/
+# We use `mypy` to perform static type checking of our Python code.
+# PyPI: https://pypi.org/project/mypy
 mypy==1.20.2
+# We use `types-requests` to get type information about the `requests` package.
+# PyPI: https://pypi.org/project/types-requests/
+types-requests==2.33.0.20260408
+# We use `pandas-stubs` to get type information about the `pandas` package.
+# PyPI: https://pypi.org/project/pandas-stubs/
+pandas-stubs==3.0.0.260204


### PR DESCRIPTION
On this branch, I introduced the `mypy` package as a development dependency. I put a default configuration for mypy in the `pyproject.toml` file, which tells mypy to check the contents of the `nmdc_api_utilities` directory (recursively). I also added a new section about using mypy, entitled "Static type checking", to the contributor's guide.

Also, I defined a pre-commit hook that runs mypy. This was my first time defining a pre-commit hook. I opted to make the hook be **non-blocking** while we get used to working with mypy.

mypy reported 39 errors across 13 files. I have attempted to resolve all of them in a way that minimizes changes to existing code in this repository. In addition, I fixed a bug (brought to my attention by Codex) related to iterating over the characters of a string instead of the strings in a list. I also added a `TODO` about a potential bug related to quote replacement.

Finally, some of the "type" info in the docstrings contradicts the type hints and usage. I suggest omitting "type" info from docstrings and use type hints instead since the latter can be programmatically validated (e.g. via mypy). I wonder whether Sphinx can get the type info from the type hints instead of the docstring (update: I think it [can](https://pypi.org/project/sphinx-autodoc-typehints/)). We can do that in a follow-on PR.