### PR TITLE
Make sure `hydrate` results get passed on in the `get_linked_instances_and_associate_ids` function

### DIFF
--- a/nmdc_api_utilities/nmdc_search.py
+++ b/nmdc_api_utilities/nmdc_search.py
@@ -152,7 +152,7 @@ class NMDCSearch(NMDCAPIClient):
         linked_instances = self.get_linked_instances(
             types=types, ids=ids, hydrate=hydrate, max_page_size=max_page_size
         )
-        association: dict[str, list[dict] | list[str]] = {}
+        association: dict[str, list[dict | str]] = {}
         # loop through the linked instances and build the association
         for record in linked_instances:
             for stream in ["_upstream_of", "_downstream_of"]:

--- a/nmdc_api_utilities/nmdc_search.py
+++ b/nmdc_api_utilities/nmdc_search.py
@@ -151,14 +151,9 @@ class NMDCSearch(NMDCAPIClient):
                         if stream_id not in association:
                             association[stream_id] = []
                         if hydrate:
-                            hydrate_dict = {
-                                id: {
-                                    key: record[key]
-                                    for key in record.keys()
-                                    if key not in [stream, "id"]
-                                }
-                            }
-                            association[stream_id].append(hydrate_dict)
+                            association[stream_id].append(
+                                {key: record[key] for key in record if key != stream}
+                            )
                         else:
                             association[stream_id].append(id)
                 else:

--- a/nmdc_api_utilities/nmdc_search.py
+++ b/nmdc_api_utilities/nmdc_search.py
@@ -144,17 +144,29 @@ class NMDCSearch(NMDCAPIClient):
         association = {}
         # loop through the linked instances and build the association
         for record in linked_instances:
-            study_id = record["id"]
-            if "_upstream_of" in record:
-                for upstream_id in record["_upstream_of"]:
-                    if upstream_id not in association:
-                        association[upstream_id] = []
-                    association[upstream_id].append(study_id)
-            if "_downstream_of" in record:
-                for upstream_id in record["_downstream_of"]:
-                    if upstream_id not in association:
-                        association[upstream_id] = []
-                    association[upstream_id].append(study_id)
+            id = record["id"]
+            stream = (
+                "_upstream_of"
+                if "_upstream_of" in record
+                else "_downstream_of"
+                if "_downstream_of" in record
+                else None
+            )
+            if stream is not None:
+                for stream_id in record[stream]:
+                    if stream_id not in association:
+                        association[stream_id] = []
+                    if hydrate:
+                        hydrate_dict = {
+                            id: {
+                                key: record[key]
+                                for key in record.keys()
+                                if key not in [stream, "id"]
+                            }
+                        }
+                        association[stream_id].append(hydrate_dict)
+                    else:
+                        association[stream_id].append(id)
 
         return association
 

--- a/nmdc_api_utilities/nmdc_search.py
+++ b/nmdc_api_utilities/nmdc_search.py
@@ -109,7 +109,7 @@ class NMDCSearch(NMDCAPIClient):
         types: list[str] | str = None,
         hydrate: bool = False,
         max_page_size: int = 500,
-    ) -> dict[str, list[str]]:
+    ) -> dict[str, list[dict] | list[str]]:
         """
         Retrieve linked instances for the given IDs from the NMDC API and associate them with the input IDs.
 
@@ -134,7 +134,7 @@ class NMDCSearch(NMDCAPIClient):
 
         Returns
         -------
-        dict[str, list[str]]
+        dict[str, list[dict] | list[str]]
             A dictionary mapping each input id to a list of its linked instance records.
         """
         # get the linked instances
@@ -145,28 +145,24 @@ class NMDCSearch(NMDCAPIClient):
         # loop through the linked instances and build the association
         for record in linked_instances:
             id = record["id"]
-            stream = (
-                "_upstream_of"
-                if "_upstream_of" in record
-                else "_downstream_of"
-                if "_downstream_of" in record
-                else None
-            )
-            if stream is not None:
-                for stream_id in record[stream]:
-                    if stream_id not in association:
-                        association[stream_id] = []
-                    if hydrate:
-                        hydrate_dict = {
-                            id: {
-                                key: record[key]
-                                for key in record.keys()
-                                if key not in [stream, "id"]
+            for stream in ["_upstream_of", "_downstream_of"]:
+                if stream in record:
+                    for stream_id in record[stream]:
+                        if stream_id not in association:
+                            association[stream_id] = []
+                        if hydrate:
+                            hydrate_dict = {
+                                id: {
+                                    key: record[key]
+                                    for key in record.keys()
+                                    if key not in [stream, "id"]
+                                }
                             }
-                        }
-                        association[stream_id].append(hydrate_dict)
-                    else:
-                        association[stream_id].append(id)
+                            association[stream_id].append(hydrate_dict)
+                        else:
+                            association[stream_id].append(id)
+                else:
+                    continue
 
         return association
 

--- a/nmdc_api_utilities/nmdc_search.py
+++ b/nmdc_api_utilities/nmdc_search.py
@@ -129,7 +129,7 @@ class NMDCSearch(NMDCAPIClient):
         ``data_generation_set`` etc that are associated with this study, even if it is not a single link between records.
 
         See also ``get_linked_instances`` for a method that returns the linked instances in their original list format.
-        This method reformats into a dictionary with keys as query ids, and a list of resulting linked ids as values.
+        This method reformats into a dictionary with keys as query ids, and either a list of resulting linked ids or a list of hydrated records as values.
 
 
         Parameters
@@ -152,10 +152,9 @@ class NMDCSearch(NMDCAPIClient):
         linked_instances = self.get_linked_instances(
             types=types, ids=ids, hydrate=hydrate, max_page_size=max_page_size
         )
-        association: dict[str, list[str]] = {}
+        association: dict[str, list[dict] | list[str]] = {}
         # loop through the linked instances and build the association
         for record in linked_instances:
-            id = record["id"]
             for stream in ["_upstream_of", "_downstream_of"]:
                 if stream in record:
                     for stream_id in record[stream]:
@@ -166,7 +165,7 @@ class NMDCSearch(NMDCAPIClient):
                                 {key: record[key] for key in record if key != stream}
                             )
                         else:
-                            association[stream_id].append(id)
+                            association[stream_id].append(record["id"])
                 else:
                     continue
 

--- a/nmdc_api_utilities/nmdc_search.py
+++ b/nmdc_api_utilities/nmdc_search.py
@@ -120,7 +120,7 @@ class NMDCSearch(NMDCAPIClient):
         types: list[str] | str | None = None,
         hydrate: bool = False,
         max_page_size: int = 500,
-    ) -> dict[str, list[dict] | list[str]]:
+    ) -> dict[str, list[dict | str]]:
         """
         Retrieve linked instances for the given IDs from the NMDC API and associate them with the input IDs.
 

--- a/nmdc_api_utilities/test/test_linked_instances.py
+++ b/nmdc_api_utilities/test/test_linked_instances.py
@@ -544,9 +544,43 @@ def test_get_linked_instance_strings():
     assert len(result) == 2
 
 
+def test_get_linked_instance_hydrate():
+    """
+    Test to get a record and hydrate it.
+    """
+    ll_client = NMDCSearch(api_base_url=API_BASE_URL)
+    id = "nmdc:bsm-11-002vgm56"
+    result = ll_client.get_linked_instances(types="nmdc:Study", ids=id, hydrate=True)
+
+    assert len(result[0].keys()) > 3 and len(result[1].keys()) > 3
+
+
 def test_association():
     ll_client = NMDCSearch(api_base_url=API_BASE_URL)
     association = ll_client.get_linked_instances_and_associate_ids(
         types=["nmdc:Study"], ids=["nmdc:bsm-11-002vgm56", "nmdc:bsm-11-006pnx90"]
     )
     assert "nmdc:bsm-11-002vgm56" and "nmdc:bsm-11-006pnx90" in association.keys()
+
+
+def test_association_hydrate():
+    """
+    Test to get associated ids and hydrate them.
+    """
+    ll_client = NMDCSearch(api_base_url=API_BASE_URL)
+    association = ll_client.get_linked_instances_and_associate_ids(
+        types=["nmdc:Study"],
+        ids=["nmdc:bsm-11-002vgm56", "nmdc:bsm-11-006pnx90"],
+        hydrate=False,
+    )
+    association = ll_client.get_linked_instances_and_associate_ids(
+        types=["nmdc:Study"],
+        ids=["nmdc:bsm-11-002vgm56", "nmdc:bsm-11-006pnx90"],
+        hydrate=True,
+    )
+    assert (
+        len(next(iter(association["nmdc:bsm-11-002vgm56"][0].values()))) > 3
+        and len(next(iter(association["nmdc:bsm-11-002vgm56"][1].values()))) > 3
+        and len(next(iter(association["nmdc:bsm-11-006pnx90"][0].values()))) > 3
+        and len(next(iter(association["nmdc:bsm-11-006pnx90"][1].values()))) > 3
+    )

--- a/nmdc_api_utilities/test/test_linked_instances.py
+++ b/nmdc_api_utilities/test/test_linked_instances.py
@@ -571,14 +571,13 @@ def test_association_hydrate():
     Test to get associated ids and hydrate them.
     """
     ll_client = NMDCSearch(api_base_url=API_BASE_URL)
-    association = ll_client.get_linked_instances_and_associate_ids(
+    associations = ll_client.get_linked_instances_and_associate_ids(
         types=["nmdc:Study"],
         ids=["nmdc:bsm-11-002vgm56", "nmdc:bsm-11-006pnx90"],
         hydrate=True,
     )
     assert all(
-        "type" in inner
-        for records in association.values()
-        for record in records
-        for inner in record.values()
+        "type" in association.keys()
+        for biosample_associations in associations.values()
+        for association in biosample_associations
     )

--- a/nmdc_api_utilities/test/test_linked_instances.py
+++ b/nmdc_api_utilities/test/test_linked_instances.py
@@ -552,7 +552,7 @@ def test_get_linked_instance_hydrate():
     id = "nmdc:bsm-11-002vgm56"
     result = ll_client.get_linked_instances(types="nmdc:Study", ids=id, hydrate=True)
 
-    assert len(result[0].keys()) > 3 and len(result[1].keys()) > 3
+    assert all("id" in record and "type" in record for record in result)
 
 
 def test_association():
@@ -560,7 +560,10 @@ def test_association():
     association = ll_client.get_linked_instances_and_associate_ids(
         types=["nmdc:Study"], ids=["nmdc:bsm-11-002vgm56", "nmdc:bsm-11-006pnx90"]
     )
-    assert "nmdc:bsm-11-002vgm56" and "nmdc:bsm-11-006pnx90" in association.keys()
+    assert (
+        "nmdc:bsm-11-002vgm56" in association.keys()
+        and "nmdc:bsm-11-006pnx90" in association.keys()
+    )
 
 
 def test_association_hydrate():
@@ -571,16 +574,11 @@ def test_association_hydrate():
     association = ll_client.get_linked_instances_and_associate_ids(
         types=["nmdc:Study"],
         ids=["nmdc:bsm-11-002vgm56", "nmdc:bsm-11-006pnx90"],
-        hydrate=False,
-    )
-    association = ll_client.get_linked_instances_and_associate_ids(
-        types=["nmdc:Study"],
-        ids=["nmdc:bsm-11-002vgm56", "nmdc:bsm-11-006pnx90"],
         hydrate=True,
     )
-    assert (
-        len(next(iter(association["nmdc:bsm-11-002vgm56"][0].values()))) > 3
-        and len(next(iter(association["nmdc:bsm-11-002vgm56"][1].values()))) > 3
-        and len(next(iter(association["nmdc:bsm-11-006pnx90"][0].values()))) > 3
-        and len(next(iter(association["nmdc:bsm-11-006pnx90"][1].values()))) > 3
+    assert all(
+        "type" in inner
+        for records in association.values()
+        for record in records
+        for inner in record.values()
     )

--- a/nmdc_api_utilities/test/test_linked_instances.py
+++ b/nmdc_api_utilities/test/test_linked_instances.py
@@ -549,8 +549,10 @@ def test_get_linked_instance_hydrate():
     Test to get a record and hydrate it.
     """
     ll_client = NMDCSearch(api_base_url=API_BASE_URL)
-    id = "nmdc:bsm-11-002vgm56"
-    result = ll_client.get_linked_instances(types="nmdc:Study", ids=id, hydrate=True)
+    search_id = "nmdc:bsm-11-002vgm56"
+    result = ll_client.get_linked_instances(
+        types="nmdc:Study", ids=search_id, hydrate=True
+    )
 
     assert all("id" in record and "type" in record for record in result)
 


### PR DESCRIPTION
Pass additional information provided by the `hydrate` parameter  on `get_linked_instances` to the `get_linked_instances_and_associate_ids` output via a nested dictionary

Original output:
`{'nmdc:bsm-11-002vgm56': ['nmdc:sty-11-34xj1150', 'nmdc:sty-11-nxrz9m96'], 'nmdc:bsm-11-006pnx90': ['nmdc:sty-11-e4yb9z58', 'nmdc:sty-11-y1kdd163']}`

New output (fixed 4pm 4/24):
`{'nmdc:bsm-11-002vgm56': [{'id':'nmdc:sty-11-34xj1150', 'type': 'nmdc:Study', 'description':....}, {'id':'nmdc:sty-11-nxrz9m96',{'type': 'nmdc:Study', 'description':...}], {'nmdc:bsm-11-006pnx90': [{'id':'nmdc:sty-11-e4yb9z58', 'type': 'nmdc:Study', 'description':...}, {'id':'nmdc:sty-11-y1kdd163','type': 'nmdc:Study', 'description':...}]}`