### PR TITLE
rename `collection_id` parameter on `CollectionSearch`'s `get_record_by_id`

### DIFF
--- a/nmdc_api_utilities/collection_search.py
+++ b/nmdc_api_utilities/collection_search.py
@@ -4,6 +4,7 @@ import json
 import logging
 import re
 import urllib.parse
+from typing import Optional
 
 import requests
 
@@ -176,10 +177,10 @@ class CollectionSearch(NMDCSearch):
 
     def get_record_by_id(
         self,
-        record_id: str = None,
+        record_id: Optional[str] = None,
         max_page_size: int = 100,
         fields: str = "",
-        collection_id: str = None,
+        collection_id: Optional[str] = None,
     ) -> list[dict]:
         """
         Retrieve a record from the collection via the NMDC API using a specified ID.

--- a/nmdc_api_utilities/collection_search.py
+++ b/nmdc_api_utilities/collection_search.py
@@ -176,21 +176,24 @@ class CollectionSearch(NMDCSearch):
 
     def get_record_by_id(
         self,
-        collection_id: str,
+        record_id: str = None,
         max_page_size: int = 100,
         fields: str = "",
+        collection_id: str = None,
     ) -> list[dict]:
         """
         Retrieve a record from the collection via the NMDC API using a specified ID.
 
         Parameters
         ----------
-        collection_id: str
-            The id of the record to retrieve from the collection.
+        record_id: str
+            The id of the record to retrieve from the collection. Not required to enable backwards compatibility with the deprecated collection_id parameter.
         max_page_size: int
             The maximum number of records to return per page. Default is 100.
         fields: str
             The fields to return. Default is all fields.
+        collection_id: str, DEPRECATED
+            The id of the record to retrieve from the collection. This parameter is deprecated and will be removed in a future version. Please use record_id instead.
 
         Returns
         -------
@@ -208,7 +211,21 @@ class CollectionSearch(NMDCSearch):
                 f"get_record_by_id is not supported for the {self.collection_name} collection"
             )
 
-        url = f"{self.api_base_url}/nmdcschema/{self.collection_name}/{collection_id}?max_page_size={max_page_size}&projection={fields}"
+        if record_id is None and collection_id is None:
+            raise ValueError(
+                "No record_id provided. Please provide this parameter to retrieve a record."
+            )
+        if record_id and collection_id:
+            raise ValueError(
+                "Both record_id and collection_id were provided. Please provide record_id, as collection_id is deprecated and will be removed in a future version."
+            )
+        if collection_id:
+            logger.warning(
+                "The collection_id parameter is deprecated and will be removed in a future version. Please use record_id instead."
+            )
+            record_id = collection_id
+
+        url = f"{self.api_base_url}/nmdcschema/{self.collection_name}/{record_id}?max_page_size={max_page_size}&projection={fields}"
         # get the reponse
         try:
             response = requests.get(

--- a/nmdc_api_utilities/test/test_collection.py
+++ b/nmdc_api_utilities/test/test_collection.py
@@ -2,6 +2,8 @@
 import logging
 import unittest
 
+import pytest
+
 from nmdc_api_utilities.collection_search import CollectionSearch
 from nmdc_api_utilities.config import API_BASE_URL
 
@@ -42,6 +44,28 @@ class TestCollection(unittest.TestCase):
         collection = CollectionSearch("study_set", api_base_url=API_BASE_URL)
         results = collection.get_record_by_id("nmdc:sty-11-8fb6t785")
         assert results["id"] == "nmdc:sty-11-8fb6t785"
+
+    def test_get_record_by_id_params(self):
+        # simple test to check if the get_record_by_id method returns a record for the two id parameters (record_id (current), collection_id (deprecated))
+        collection = CollectionSearch("study_set", api_base_url=API_BASE_URL)
+
+        with self.assertLogs(level=logging.WARNING) as cm:
+            results_collect_id = collection.get_record_by_id(
+                collection_id="nmdc:sty-11-8fb6t785"
+            )
+        assert results_collect_id["id"] == "nmdc:sty-11-8fb6t785"
+        self.assertIn("deprecated", "\n".join(cm.output))
+
+        results_record_id = collection.get_record_by_id(
+            record_id="nmdc:sty-11-8fb6t785"
+        )
+        assert results_record_id["id"] == "nmdc:sty-11-8fb6t785"
+
+        with pytest.raises(ValueError, match="Both.*record_id.*collection_id"):
+            collection.get_record_by_id(
+                record_id="nmdc:sty-11-8fb6t785",
+                collection_id="nmdc:sty-11-8fb6t785",
+            )
 
     def test_check_ids_exist(self):
         # simple test to check if the check_ids_exist method returns a boolean


### PR DESCRIPTION
- renamed `collection_id` to `record_id` in `get_record_by_id`
- `collection_id` moved to end of parameters, made optional and noted as deprecated in doc string
- `record_id` also made optional for backwards compatibility
- Runtime ValueErrors added if both `collection_id` and `record_id` are provided or if neither is provided
- Warning logged if just `collection_id` is provided, noting that it is deprecated