### PR TITLE
Update third-party GHA versions to avoid Node version swap surprise

### DIFF
--- a/.github/workflows/dev_tests.yml
+++ b/.github/workflows/dev_tests.yml
@@ -17,8 +17,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6  # docs: https://github.com/marketplace/actions/checkout
+      - uses: actions/setup-python@v6  # docs: https://github.com/marketplace/actions/setup-python
         with:
             python-version: 3.12
       - name: Set up environment variables

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -13,8 +13,8 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6  # docs: https://github.com/marketplace/actions/checkout
+      - uses: actions/setup-python@v6  # docs: https://github.com/marketplace/actions/setup-python
       - name: Install dependencies
         run: |
           pip install sphinx sphinx_rtd_theme myst_parser

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -19,12 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6  # docs: https://github.com/marketplace/actions/checkout
         with:
           ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6  # docs: https://github.com/marketplace/actions/setup-python
         with:
           python-version: 3.12
 

--- a/.github/workflows/prod_tests.yml
+++ b/.github/workflows/prod_tests.yml
@@ -17,8 +17,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6  # docs: https://github.com/marketplace/actions/checkout
+      - uses: actions/setup-python@v6  # docs: https://github.com/marketplace/actions/setup-python
         with:
             python-version: 3.12
       - name: Set up environment variables


### PR DESCRIPTION
GitHub has deprecated some old Action versions. Per their blog:

> Node20 will reach end-of-life (EOL) in April of 2026. As a result we have started the deprecation process of Node20 for GitHub Actions. We plan to migrate all actions to run on Node24 in the fall of 2026.
>
> [...]
>
> What you need to do:
> 
> [...]
> 
> For Actions users: Update your workflows with latest versions of the actions that run on Node24 ([Using versions for Actions](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-versioned-actions))

On this branch, I did the "what you need to do" thing described above.

Fixes #175 