### PR TITLE
Remove types from docstrings and configure Sphinx to read type hints

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-python@v6  # docs: https://github.com/marketplace/actions/setup-python
       - name: Install dependencies
         run: |
-          pip install sphinx sphinx_rtd_theme myst_parser
+          pip install sphinx sphinx_rtd_theme myst_parser sphinx-autodoc-typehints
           pip install .
           pip install -r requirements.txt
       - name: Sphinx build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,7 +148,7 @@ In development, you can build and preview the documentation website locally by f
    ```sh
     pip install -r requirements.txt
     pip install -r requirements-dev.txt
-    pip install myst_parser
+    pip install myst_parser sphinx-autodoc-typehints
     pip install .
    ```
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,12 +24,14 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",  # For Google/NumPy style docstrings
     "sphinx.ext.viewcode",  # Add links to source code
-    "sphinx_autodoc_typehints",  # Automatically include type hints in the documentation
+    "sphinx_autodoc_typehints",  # For automatically including type hints in the documentation
 ]
 
 templates_path = ["_templates"]
 exclude_patterns = ["build", "Thumbs.db", ".DS_Store"]
 
+# This setting adds the default values of function parameters to the documentation without needing to include them in the docstring.
+typehints_defaults = "comma"
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,6 +24,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",  # For Google/NumPy style docstrings
     "sphinx.ext.viewcode",  # Add links to source code
+    "sphinx_autodoc_typehints",  # Automatically include type hints in the documentation
 ]
 
 templates_path = ["_templates"]

--- a/docs/public_subclasses.rst
+++ b/docs/public_subclasses.rst
@@ -1,4 +1,4 @@
-`CollectionSearch` Subclasses
+``CollectionSearch`` Subclasses
 ============================
 
 Collection-specific subclasses are the recommended public entry points.

--- a/nmdc_api_utilities/api_client.py
+++ b/nmdc_api_utilities/api_client.py
@@ -18,7 +18,7 @@ class NMDCAPIClient(ABC):
 
     Parameters
     ----------
-    api_base_url: str
+    api_base_url
         The base URL of an instance of the NMDC Runtime API. By default, this is the base URL of
         the production instance. NMDC team members will occasionally set this to the base URL of
         a different instance; for example, a self-hosted instance used for testing.

--- a/nmdc_api_utilities/auth.py
+++ b/nmdc_api_utilities/auth.py
@@ -18,18 +18,18 @@ class NMDCAuth(NMDCAPIClient):
 
     Parameters
     ----------
-    client_id : str
+    client_id
         The client ID for NMDC API authentication. See Notes for further details.
-    client_secret : str
+    client_secret
         The client secret for NMDC API authentication. See Notes for further details.
-    username : str
+    username
         The username for NMDC API authentication. See Notes for further details.
-    password : str
+    password
         The password for NMDC API authentication. See Notes for further details.
-    api_base_url : str
+    api_base_url
         The base URL of an instance of the NMDC Runtime API. By default, this is the base URL of
         the production instance.
-    env : str
+    env
         Deprecated. Use `api_base_url` instead. Previously used to specify the API environment
         (e.g., "prod", "dev").
 

--- a/nmdc_api_utilities/collection_search.py
+++ b/nmdc_api_utilities/collection_search.py
@@ -56,13 +56,13 @@ class CollectionSearch(NMDCSearch):
 
         Parameters
         ----------
-        filter:
+        filter
             The filter to apply to the query. Default is an empty string.
-        max_page_size:
+        max_page_size
             The maximum number of records to return per page. Default is 100.
-        fields:
+        fields
             The fields to return. Default is all fields.
-        all_pages:
+        all_pages
             True to return all pages. False to return the first page. Default is False.
 
         Returns

--- a/nmdc_api_utilities/collection_search.py
+++ b/nmdc_api_utilities/collection_search.py
@@ -34,7 +34,7 @@ class CollectionSearch(NMDCSearch):
 
     def __init__(
         self,
-        collection_name,
+        collection_name: str,
         api_base_url: str = API_BASE_URL,
         env: str = "",
     ):
@@ -57,13 +57,13 @@ class CollectionSearch(NMDCSearch):
         Parameters
         ----------
         filter
-            The filter to apply to the query. Default is an empty string.
+            The filter to apply to the query. An empty string will return all records.
         max_page_size
-            The maximum number of records to return per page. Default is 100.
+            The maximum number of records to return per page.
         fields
-            The fields to return. Default is all fields.
+            The fields to return. An empty string will return all fields.
         all_pages
-            True to return all pages. False to return the first page. Default is False.
+            True to return all pages. False to return the first page.
 
         Returns
         -------

--- a/nmdc_api_utilities/collection_search.py
+++ b/nmdc_api_utilities/collection_search.py
@@ -23,6 +23,13 @@ class OperationNotSupportedError(RuntimeError):
 class CollectionSearch(NMDCSearch):
     """
     Class to interact with the NMDC API to search for records within a specified collection.
+
+    Parameters
+    ----------
+    collection_name
+        The name of the collection to search within.
+    api_base_url
+        The base URL of an instance of the NMDC Runtime API. By default, this is the base URL of the production instance.
     """
 
     def __init__(
@@ -49,13 +56,13 @@ class CollectionSearch(NMDCSearch):
 
         Parameters
         ----------
-        filter: str
+        filter:
             The filter to apply to the query. Default is an empty string.
-        max_page_size: int
+        max_page_size:
             The maximum number of records to return per page. Default is 100.
-        fields: str
+        fields:
             The fields to return. Default is all fields.
-        all_pages: bool
+        all_pages:
             True to return all pages. False to return the first page. Default is False.
 
         Returns
@@ -98,24 +105,28 @@ class CollectionSearch(NMDCSearch):
         return results
 
     def get_record_by_filter(
-        self, filter: str, max_page_size=25, fields: str = "", all_pages=False
+        self,
+        filter: str,
+        max_page_size: int = 25,
+        fields: str = "",
+        all_pages: bool = False,
     ) -> list[dict]:
         """
         Retrieve a record via the NMDC API using a specified filter.
 
         Parameters
         ----------
-        filter: str
+        filter
             The filter to use to query the collection. Must be in MonogDB query format.
             Example: {"name":"my record name"}.
             `More resources found here for construction MongoDB filters <https://www.mongodb.com/docs/manual/reference/method/db.collection.find/#std-label-method-find-query>`_.
-        max_page_size: int
-            The number of records to return per page. Default is 25.
-        fields: str
-            The fields to return. Default is all fields.
+        max_page_size
+            The number of records to return per page.
+        fields
+            The fields to return. Default will return all fields.
             Example: "id,name,description,url,type"
-        all_pages: bool
-            True to return all pages. False to return the first page. Default is False.
+        all_pages
+            True to return all pages. False to return the first page.
 
         Returns
         -------
@@ -140,17 +151,17 @@ class CollectionSearch(NMDCSearch):
 
         Parameters
         ----------
-        attribute_name: str
+        attribute_name
             The name of the attribute to filter by.
-        attribute_value: str
+        attribute_value
             The value of the attribute to filter by.
-        max_page_size: int
-            The number of records to return per page. Default is 25.
-        fields: str
-            The fields to return. Default is all fields.
-        all_pages: bool
-            True to return all pages. False to return the first page. Default is False.
-        exact_match: bool
+        max_page_size
+            The number of records to return per page.
+        fields
+            The fields to return. Default will return all fields.
+        all_pages
+            True to return all pages. False to return the first page.
+        exact_match
             Whether the attribute value should be matched exactly or partially.
             Used to determine if the inputted attribute value is an exact match or a partial match.
             Default is False, meaning the user does not need to input an exact match.
@@ -185,12 +196,12 @@ class CollectionSearch(NMDCSearch):
 
         Parameters
         ----------
-        collection_id: str
+        collection_id
             The id of the record to retrieve from the collection.
-        max_page_size: int
-            The maximum number of records to return per page. Default is 100.
-        fields: str
-            The fields to return. Default is all fields.
+        max_page_size
+            The maximum number of records to return per page.
+        fields
+            The fields to return. Default will return all fields.
 
         Returns
         -------
@@ -239,12 +250,12 @@ class CollectionSearch(NMDCSearch):
 
         Parameters
         ----------
-        ids : list
+        ids
             A list of IDs to check if they exist in the collection.
-        chunk_size : int
-            The number of IDs to check in each query. Default is 100.
-        return_missing_ids : bool
-            If True, and if ids are missing in the collection, return the list of IDs that do not exist in the collection. Default is False.
+        chunk_size
+            The number of IDs to check in each query.
+        return_missing_ids
+            If True, and if ids are missing in the collection, return the list of IDs that do not exist in the collection.
 
         Returns
         -------
@@ -279,7 +290,7 @@ class CollectionSearch(NMDCSearch):
         return True
 
     def get_batch_records(
-        self, id_list: list, search_field: str, chunk_size=100, fields=""
+        self, id_list: list, search_field: str, chunk_size: int = 100, fields: str = ""
     ) -> list[dict]:
         """
         Get a batch of records from the collection that relate to input IDs.
@@ -290,14 +301,14 @@ class CollectionSearch(NMDCSearch):
 
         Parameters
         ---------
-        id_list: list
+        id_list
             A list of IDs to get records for.
-        search_field: str
+        search_field
             The field in which to search for the IDs.
-        chunk_size: int
-            The number of IDs to get in each query. Default is 100.
-        fields: str
-            The fields to return. Default is all fields.
+        chunk_size
+            The number of IDs to get in each query.
+        fields
+            The fields to return. Default will return all fields.
 
         Returns
         -------

--- a/nmdc_api_utilities/collection_search.py
+++ b/nmdc_api_utilities/collection_search.py
@@ -117,9 +117,9 @@ class CollectionSearch(NMDCSearch):
         Parameters
         ----------
         filter
-            The filter to use to query the collection. Must be in MonogDB query format.
+            The filter to use to query the collection. Must be in MongoDB query format.
             Example: {"name":"my record name"}.
-            `More resources found here for construction MongoDB filters <https://www.mongodb.com/docs/manual/reference/method/db.collection.find/#std-label-method-find-query>`_.
+            `More resources for constructing MongoDB filters can be found here <https://www.mongodb.com/docs/manual/reference/method/db.collection.find/#std-label-method-find-query>`_.
         max_page_size
             The number of records to return per page.
         fields
@@ -158,7 +158,7 @@ class CollectionSearch(NMDCSearch):
         max_page_size
             The number of records to return per page.
         fields
-            The fields to return. Default will return all fields.
+            The fields to return. If empty, all fields are returned.
         all_pages
             True to return all pages. False to return the first page.
         exact_match
@@ -308,7 +308,7 @@ class CollectionSearch(NMDCSearch):
         chunk_size
             The number of IDs to get in each query.
         fields
-            The fields to return. Default will return all fields.
+            The fields to return. If empty or not provided, all fields are returned.
 
         Returns
         -------

--- a/nmdc_api_utilities/data_object_search.py
+++ b/nmdc_api_utilities/data_object_search.py
@@ -56,12 +56,14 @@ class DataObjectSearch(CollectionSearch):
 
         Parameters
         ----------
-        study_id: str
+        study_id
             The ID of the study.
+
         Returns
         -------
         list[dict]
             The data objects.
+
         Raises
         ------
         RuntimeError

--- a/nmdc_api_utilities/data_processing.py
+++ b/nmdc_api_utilities/data_processing.py
@@ -85,7 +85,7 @@ class DataProcessing:
         df
             The pandas dataframe to rename columns.
         new_col_names
-            A list of new column names. Names MUST be in order of the columns in the dataframe.\n
+            A list of new column names. Names MUST be in order of the columns in the dataframe.
             Example:
                 If the current column names are - ['old_col1', 'old_col2', 'old_col3']
                 You will need to pass in the new names like - ['new_col1', 'new_col2', 'new_col3']

--- a/nmdc_api_utilities/data_processing.py
+++ b/nmdc_api_utilities/data_processing.py
@@ -41,7 +41,7 @@ class DataProcessing:
 
         Parameters
         ----------
-        data: list
+        data
             A list of dictionaries.
 
         Returns
@@ -59,9 +59,9 @@ class DataProcessing:
 
         Parameters
         ----------
-        input_list: list
+        input_list
             The list to split.
-        chunk_size: int
+        chunk_size
             The size of each chunk.
 
         Returns
@@ -82,9 +82,9 @@ class DataProcessing:
 
         Parameters
         ----------
-        df: pd.DataFrame
+        df
             The pandas dataframe to rename columns.
-        new_col_names: list
+        new_col_names
             A list of new column names. Names MUST be in order of the columns in the dataframe.\n
             Example:
                 If the current column names are - ['old_col1', 'old_col2', 'old_col3']
@@ -109,11 +109,11 @@ class DataProcessing:
 
         Parameters
         ----------
-        column: str
+        column
             The column to merge on.
-        df1: pd.DataFrame
+        df1
             The first dataframe to merge.
-        df2: pd.DataFrame
+        df2
             The second dataframe to merge.
 
         Returns
@@ -137,13 +137,13 @@ class DataProcessing:
 
         Parameters
         ----------
-        df1: pd.DataFrame
+        df1
             The first dataframe to merge.
-        df2: pd.DataFrame
+        df2
             The second dataframe to merge.
-        key1: str
+        key1
             The key in df1 to match with key2 in df2.
-        key2: str
+        key2
             The key in df2 to match with key1 in df1.
 
         Returns
@@ -176,10 +176,10 @@ class DataProcessing:
 
         Parameters
         ----------
-        attributes: dict
+        attributes
             Dictionary of attribute names and their corresponding values to match using regex.
             Example: {"name": "example", "description": "example", "geo_loc_name": "example"}
-        exact_match: bool
+        exact_match
             This var is used to determine if the inputted attribute value is an exact match or a partial match. Default is False, meaning the user does not need to input an exact match.
             Under the hood this is used to determine if the inputted attribute value should be wrapped in a regex expression.
         Returns
@@ -215,9 +215,9 @@ class DataProcessing:
 
         Parameters
         ----------
-        api_results: list
+        api_results
             A list of dictionaries.
-        field_name: str
+        field_name
             The name of the field to extract.
 
         Returns

--- a/nmdc_api_utilities/data_staging.py
+++ b/nmdc_api_utilities/data_staging.py
@@ -16,6 +16,15 @@ logger = logging.getLogger(__name__)
 class JGISequencingProjectAPI(NMDCAPIClient):
     """
     Class to interact with the NMDC API to get JGI samples.
+
+    Parameters
+    ----------
+    auth
+        The NMDCAuth instance containing the credentials and API base URL for authentication.
+    api_base_url
+        The base URL of an instance of the NMDC Runtime API. By default, this is the base URL of the production instance.
+    env
+        Deprecated. Use `api_base_url` instead. Previously used to specify the API environment (e.g., "prod", "dev").
     """
 
     def __init__(
@@ -51,7 +60,7 @@ class JGISequencingProjectAPI(NMDCAPIClient):
 
         Parameters
         ----------
-        jgi_sequencing_project : dict
+        jgi_sequencing_project
             The JGI sequencing project data to be created.
 
         Returns
@@ -97,13 +106,13 @@ class JGISequencingProjectAPI(NMDCAPIClient):
 
         Parameters
         ----------
-        filter : str, optional
+        filter
             Filter to apply to the API call.
-        max_page_size : int, optional
+        max_page_size
             The maximum number of items to return per page.
-        fields : str, optional
+        fields
             The fields to return.
-        all_pages : bool, optional
+        all_pages
             True to return all pages. False to return the first page.
 
         Returns
@@ -153,7 +162,7 @@ class JGISequencingProjectAPI(NMDCAPIClient):
 
         Parameters
         ----------
-        project_name : str
+        project_name
             The name of the JGI sequencing project to retrieve.
 
         Returns
@@ -183,6 +192,15 @@ class JGISequencingProjectAPI(NMDCAPIClient):
 class JGISampleSearchAPI(NMDCAPIClient):
     """
     Class to interact with the NMDC API to get JGI samples.
+
+    Parameters
+    ----------
+    auth
+        The NMDCAuth instance containing the credentials and API base URL for authentication.
+    api_base_url
+        The base URL of an instance of the NMDC Runtime API. By default, this is the base URL of the production instance.
+    env
+        Deprecated. Use `api_base_url` instead. Previously used to specify the API environment (e.g., "prod", "dev").
     """
 
     def __init__(
@@ -219,13 +237,13 @@ class JGISampleSearchAPI(NMDCAPIClient):
 
         Parameters
         ----------
-        filter : str, optional
+        filter
             Filter to apply to the API call.
-        max_page_size : int, optional
+        max_page_size
             The maximum number of items to return per page.
-        fields : str, optional
+        fields
             The fields to return.
-        all_pages : bool, optional
+        all_pages
             True to return all pages. False to return the first page.
 
         Returns
@@ -280,7 +298,7 @@ class JGISampleSearchAPI(NMDCAPIClient):
 
         Parameters
         ----------
-        jgi_sample : dict
+        jgi_sample
             The JGI sample data to be inserted.
 
         Returns
@@ -325,9 +343,9 @@ class JGISampleSearchAPI(NMDCAPIClient):
 
         Parameters
         ----------
-        jgi_file_id : str
+        jgi_file_id
             The JGI file ID of the sample to be updated.
-        jgi_sample : dict
+        jgi_sample
             The updated JGI sample data.
 
         Returns
@@ -363,6 +381,15 @@ class JGISampleSearchAPI(NMDCAPIClient):
 class GlobusTaskAPI(NMDCAPIClient):
     """
     Class to interact with the NMDC API for Globus tasks.
+
+    Parameters
+    ----------
+    auth
+        The NMDCAuth instance containing the credentials and API base URL for authentication.
+    api_base_url
+        The base URL of an instance of the NMDC Runtime API. By default, this is the base URL of the production instance.
+    env
+        Deprecated. Use `api_base_url` instead. Previously used to specify the API environment (e.g., "prod", "dev").
     """
 
     def __init__(
@@ -399,13 +426,13 @@ class GlobusTaskAPI(NMDCAPIClient):
 
         Parameters
         ----------
-        filter : str, optional
+        filter
             Filter to apply to the API call.
-        max_page_size : int, optional
+        max_page_size
             The maximum number of items to return per page.
-        fields : str, optional
+        fields
             The fields to return.
-        all_pages : bool, optional
+        all_pages
             True to return all pages. False to return the first page.
 
         Returns
@@ -457,7 +484,7 @@ class GlobusTaskAPI(NMDCAPIClient):
 
         Parameters
         ----------
-        globus_task : dict
+        globus_task
             The Globus task data to be created.
 
         Returns
@@ -503,9 +530,9 @@ class GlobusTaskAPI(NMDCAPIClient):
 
         Parameters
         ----------
-        globus_task_id: str
+        globus_task_id
             The ID of the Globus task to be updated.
-        globus_task : dict
+        globus_task
             The Globus task data to be updated.
 
         Returns

--- a/nmdc_api_utilities/functional_search.py
+++ b/nmdc_api_utilities/functional_search.py
@@ -31,17 +31,17 @@ class FunctionalSearch(CollectionSearch):
 
         Parameters
         -----------
-        annotation: str
+        annotation
             The functional annotation value to query.
-        annotation_type:
+        annotation_type
             The type of id to query. See Notes for more details.
-        page_size: int
-            The number of results to return per page. Default is 25.
-        fields: str
-            The fields to return. Default is all fields.
+        page_size
+            The number of results to return per page.
+        fields
+            The fields to return. Default will return all fields.
             Example: "id,name"
-        all_pages: bool
-            True to return all pages. False to return the first page. Default is False.
+        all_pages
+            True to return all pages. False to return the first page.
 
         Returns
         -------

--- a/nmdc_api_utilities/functional_search.py
+++ b/nmdc_api_utilities/functional_search.py
@@ -38,7 +38,7 @@ class FunctionalSearch(CollectionSearch):
         page_size
             The number of results to return per page.
         fields
-            The fields to return. Default will return all fields.
+            The fields to return. If empty, all fields are returned.
             Example: "id,name"
         all_pages
             True to return all pages. False to return the first page.

--- a/nmdc_api_utilities/lat_long_filters.py
+++ b/nmdc_api_utilities/lat_long_filters.py
@@ -95,7 +95,7 @@ class LatLongFilters(ABC):
         page_size
             The number of results to return per page.
         fields
-            The fields to return. Default will return all fields.
+            The fields to return. If empty, all fields are returned.
             Example: "id,name,description,type"
         all_pages
             True to return all pages. False to return the first page.
@@ -158,7 +158,7 @@ class LatLongFilters(ABC):
         page_size
             The number of results to return per page.
         fields
-            The fields to return. Default will return all fields.
+            The fields to return. If empty, all fields are returned.
             Example: "id,name,description,type"
         all_pages
             True to return all pages. False to return the first page.

--- a/nmdc_api_utilities/lat_long_filters.py
+++ b/nmdc_api_utilities/lat_long_filters.py
@@ -29,17 +29,17 @@ class LatLongFilters(ABC):
 
         Parameters
         ----------
-        comparison: str
+        comparison
             The comparison to use to query the record. See Notes for more details.
-        latitude: float
+        latitude
             The latitude of the record to query.
-        page_size: int
-            The number of results to return per page. Default is 25.
-        fields: str
+        page_size
+            The number of results to return per page.
+        fields
             The fields to return. Default is all fields.
             Example: "id,name,description,type"
-        all_pages: bool
-            True to return all pages. False to return the first page. Default is False.
+        all_pages
+            True to return all pages. False to return the first page.
 
         Returns
         -------
@@ -88,17 +88,17 @@ class LatLongFilters(ABC):
 
         Parameters
         ----------
-        comparison: str
+        comparison
             The comparison to use to query the record. See Notes for more details.
-        longitude: float
+        longitude
             The longitude of the record to query.
-        page_size: int
-            The number of results to return per page. Default is 25.
-        fields: str
-            The fields to return. Default is all fields.
+        page_size
+            The number of results to return per page.
+        fields
+            The fields to return. Default will return all fields.
             Example: "id,name,description,type"
-        all_pages: bool
-            True to return all pages. False to return the first page. Default is False.
+        all_pages
+            True to return all pages. False to return the first page.
 
         Returns
         -------
@@ -147,21 +147,21 @@ class LatLongFilters(ABC):
 
         Parameters
         ----------
-        lat_comparison: str
+        lat_comparison
             The comparison to use to query the record for latitude. See Notes for more details.
-        long_comparison: str
+        long_comparison
             The comparison to use to query the record for longitude. See Notes for more details.
-        latitude: float
+        latitude
             The latitude of the record to query.
-        longitude: float
+        longitude
             The longitude of the record to query.
-        page_size: int
-            The number of results to return per page. Default is 25.
-        fields: str
-            The fields to return. Default is all fields.
+        page_size
+            The number of results to return per page.
+        fields
+            The fields to return. Default will return all fields.
             Example: "id,name,description,type"
-        all_pages: bool
-            True to return all pages. False to return the first page. Default is False.
+        all_pages
+            True to return all pages. False to return the first page.
 
         Returns
         -------

--- a/nmdc_api_utilities/lat_long_filters.py
+++ b/nmdc_api_utilities/lat_long_filters.py
@@ -22,8 +22,13 @@ class LatLongFilters(ABC):
         """Retrieve records from a collection via the NMDC API."""
 
     def get_record_by_latitude(
-        self, comparison: str, latitude: float, page_size=25, fields="", all_pages=False
-    ):
+        self,
+        comparison: str,
+        latitude: float,
+        page_size: int = 25,
+        fields: str = "",
+        all_pages: bool = False,
+    ) -> list[dict]:
         """
         Retrieve records by latitude filter via the NMDC API.
 

--- a/nmdc_api_utilities/metadata.py
+++ b/nmdc_api_utilities/metadata.py
@@ -21,9 +21,9 @@ class Metadata(NMDCAPIClient):
 
     Parameters
     ----------
-    api_base_url : str
+    api_base_url
         The base URL of the NMDC API.
-    auth : NMDCAuth
+    auth
         An instance of the NMDCAuth class for authentication.
     """
 
@@ -47,7 +47,7 @@ class Metadata(NMDCAPIClient):
 
         Parameters
         ----------
-        json_records : list[dict] | str
+        json_records
             The json records to be validated. Can be passed in as a file path or list of dictionaries.
 
         Returns
@@ -95,7 +95,7 @@ class Metadata(NMDCAPIClient):
 
         Parameters
         ----------
-        json_records : list[dict] | str
+        json_records
             The json records to be submitted. Can be passed in as a file path or list of dictionaries.
 
         Returns

--- a/nmdc_api_utilities/minter.py
+++ b/nmdc_api_utilities/minter.py
@@ -18,10 +18,10 @@ class Minter(NMDCAPIClient):
 
     Parameters
     ----------
-    api_base_url : str
-        The base URL of the NMDC API. Default is API_BASE_URL.
-    auth : NMDCAuth
-        An instance of the NMDCAuth class for authentication. Default is None.
+    api_base_url
+        The base URL of the NMDC API.
+    auth
+        An instance of the NMDCAuth class for authentication.
     """
 
     def __init__(
@@ -49,14 +49,14 @@ class Minter(NMDCAPIClient):
 
         Parameters
         ----------
-        nmdc_type : str
+        nmdc_type
             The type of NMDC ID to mint (e.g., 'nmdc:MassSpectrometry',
             'nmdc:DataObject').
-        count : int, optional
-            The number of identifiers to mint. Default is 1.
-        client_id : str
+        count
+            The number of identifiers to mint.
+        client_id
             The client ID for authentication. Kept for backwards compatibility.
-        client_secret : str
+        client_secret
             The client secret for authentication. Kept for backwards compatibility.
 
         Returns

--- a/nmdc_api_utilities/nmdc_search.py
+++ b/nmdc_api_utilities/nmdc_search.py
@@ -16,7 +16,7 @@ class NMDCSearch(NMDCAPIClient):
 
     Parameters
     ----------
-    api_base_url: str
+    api_base_url
         The base URL of an instance of the NMDC Runtime API. By default, this is the base URL of
         the production instance. NMDC team members will occasionally set this to the base URL of
         a different instance; for example, a self-hosted instance used for testing.
@@ -50,15 +50,15 @@ class NMDCSearch(NMDCAPIClient):
 
         Parameters
         ----------
-        ids : list[str] | str
+        ids
             The ids to search for.
-        hydrate : bool = False
-            Whether to include full documents in the response. The default is False.
-        types : list[str] | str = None
-            The types of records you want to return. Default is None, which returns all types.
+        hydrate
+            Whether to include full documents in the response.
+        types
+            The types of records you want to return. Default will returns all types.
             Example: ["nmdc:Study", "nmdc:Biosample", "nmdc:MassSpectrometry"].
-        max_page_size : int = 500
-            The maximum number of records to return per page. Default is 500.
+        max_page_size
+            The maximum number of records to return per page.
 
         Returns
         -------
@@ -134,14 +134,14 @@ class NMDCSearch(NMDCAPIClient):
 
         Parameters
         ----------
-        ids : list[str] | str
+        ids
             The ids to search for.
-        types : list[str] | str = None
-            The types of instances you want to return. Default is None, which returns all types.
-        hydrate : bool = False
-            Whether to include full documents in the response. The default is False.
-        max_page_size : int = 500
-            The maximum number of records to return per page. Default is 500.
+        types
+            The types of instances you want to return. Default will return all types.
+        hydrate
+            Whether to include full documents in the response.
+        max_page_size
+            The maximum number of records to return per page.
 
         Returns
         -------
@@ -176,7 +176,7 @@ class NMDCSearch(NMDCAPIClient):
 
         Parameters
         ----------
-        doc_id: str
+        doc_id
             The id of the document.
 
         Returns
@@ -218,10 +218,10 @@ class NMDCSearch(NMDCAPIClient):
 
         Parameters
         ----------
-        ids : list[str] | str
+        ids
             List of IDs of records to retrieve.
-        fields : str
-            Comma-separated list of fields to include in the response.
+        fields
+            Comma-separated list of fields to include in the response. Default will return all fields.
 
         Returns
         -------
@@ -284,12 +284,12 @@ class NMDCSearch(NMDCAPIClient):
 
         Parameters
         ----------
-        id : str
+        id
             The ID of the record to retrieve.
-        filter : str
-            Additional filter to apply to the records.
-        fields : str
-            Comma-separated list of fields to include in the response.
+        filter
+            Additional filter to apply to the records. Default will have no filter.
+        fields
+            Comma-separated list of fields to include in the response. Default will return all fields.
 
         Returns
         -------

--- a/nmdc_api_utilities/nmdc_search.py
+++ b/nmdc_api_utilities/nmdc_search.py
@@ -55,8 +55,8 @@ class NMDCSearch(NMDCAPIClient):
         hydrate
             Whether to include full documents in the response.
         types
-            The types of records you want to return. Default will returns all types.
-            Example: ["nmdc:Study", "nmdc:Biosample", "nmdc:MassSpectrometry"].
+            The types of records to return. If omitted or ``None``, linked instances of all
+            types are returned. Example: ["nmdc:Study", "nmdc:Biosample", "nmdc:MassSpectrometry"].
         max_page_size
             The maximum number of records to return per page.
 
@@ -137,7 +137,7 @@ class NMDCSearch(NMDCAPIClient):
         ids
             The ids to search for.
         types
-            The types of instances you want to return. Default will return all types.
+            The types of instances you want to return. If ``types`` is None, all types are returned.
         hydrate
             Whether to include full documents in the response.
         max_page_size
@@ -221,7 +221,7 @@ class NMDCSearch(NMDCAPIClient):
         ids
             List of IDs of records to retrieve.
         fields
-            Comma-separated list of fields to include in the response. Default will return all fields.
+            Comma-separated list of fields to include in the response. An empty string returns all fields.
 
         Returns
         -------
@@ -287,9 +287,9 @@ class NMDCSearch(NMDCAPIClient):
         id
             The ID of the record to retrieve.
         filter
-            Additional filter to apply to the records. Default will have no filter.
+            Additional filter to apply to the records. If empty, no additional filter is applied.
         fields
-            Comma-separated list of fields to include in the response. Default will return all fields.
+            Comma-separated list of fields to include in the response. If empty, all fields are returned.
 
         Returns
         -------


### PR DESCRIPTION
Closes #172 

- Added `sphinx-autodoc-typehints` as new documentation requirement via documentation GHA and Contributing guidelines (FYI @samobermiller this is related to #176)
- Modified the `docs/conf.py` to use the **types and defaults** from the parameter definition as "source of truth" for the documentation
- Removed parameter type definitions from docstrings from all public classes and functions and reviewed their resulting rendered documentation.
- Removed explicit default value declarations from docstrings, but left some helpful documentation when functionality of default values (like empty strings) is unclear. 
- Added a few missing type hints to parameter definitions I discovered while reviewing.
- Added a couple missing docstrings I discovered while reviewing.

Note that I filed a follow up ticket to better document what is expected/not expected in the docstrings (#180).

Thanks @eecavanna for recommending this package.  Less work/maintenance,  yay!

<details>
<summary>Example of "Before" docstring and resulting rendered documentation</summary>
 
Note that `ids` parameter is documented as both `list` and `list[str]` because of inconsistency between type hint and docstring.  There is also repeated information in the docstring regarding default values.

```python
    def check_ids_exist(
        self,
        ids: list[str],
        chunk_size: int = 100,
        return_missing_ids: bool = False,
    ) -> bool | tuple[bool, list[str]]:
        """
        Check if specified IDs exist in the collection.

        This method constructs a query to the API to filter the collection based on the given IDs, and checks if all IDs exist in the collection.

        Parameters
        ----------
        ids : list
            A list of IDs to check if they exist in the collection.
        chunk_size : int
            The number of IDs to check in each query. Default is 100.
        return_missing_ids : bool
            If True, and if ids are missing in the collection, return the list of IDs that do not exist in the collection. Default is False.
        """
 ```
<img width="745" height="596" alt="Screenshot 2026-04-24 at 1 59 24 PM" src="https://github.com/user-attachments/assets/f6bbf9fe-6f4b-4c79-87ad-694c14c3125d" />
</details>

<details>
<summary>Example of "After" docstring and resulting rendered documentation</summary>

```python
    def check_ids_exist(
        self,
        ids: list[str],
        chunk_size: int = 100,
        return_missing_ids: bool = False,
    ) -> bool | tuple[bool, list[str]]:
        """
        Check if specified IDs exist in the collection.

        This method constructs a query to the API to filter the collection based on the given IDs, and checks if all IDs exist in the collection.

        Parameters
        ----------
        ids
            A list of IDs to check if they exist in the collection.
        chunk_size
            The number of IDs to check in each query.
        return_missing_ids
            If True, and if ids are missing in the collection, return the list of IDs that do not exist in the collection.
        """
```

<img width="733" height="714" alt="Screenshot 2026-04-24 at 2 01 57 PM" src="https://github.com/user-attachments/assets/7688d725-5de1-463b-8ad3-275cafb74edf" />

</details>

