### PR TITLE
Replace custom `_string_mongo_list` method with standard JSON serialization function

### DIFF
--- a/nmdc_api_utilities/collection_search.py
+++ b/nmdc_api_utilities/collection_search.py
@@ -343,7 +343,7 @@ class CollectionSearch(NMDCSearch):
         id_list = list(set(id_list))
         chunks = dp.split_list(input_list=id_list, chunk_size=chunk_size)
         for chunk in chunks:
-            sanitized_chunk = dp._string_mongo_list(data=chunk)
+            sanitized_chunk = json.dumps(chunk)
             filter = f'{{"{search_field}": {{"$in": {sanitized_chunk}}}}}'
             res = self.get_records(
                 filter=filter, max_page_size=len(chunk), fields=fields, all_pages=True

--- a/nmdc_api_utilities/data_processing.py
+++ b/nmdc_api_utilities/data_processing.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import json
 import logging
 import re
 from typing import Any
@@ -11,29 +12,6 @@ logger = logging.getLogger(__name__)
 class DataProcessing:
     def __init__(self):
         pass
-
-    def _string_mongo_list(self, data: list[Any] | dict[str, Any]) -> str:
-        """
-        Convert elements in a list to use double quotes instead of single quotes.
-        This is required for mongo queries.
-        Parameters
-        ----------
-        data: list
-            A list of dictionaries.
-        Returns
-        -------
-        str
-            A string representation of the list with double quotes.
-        """
-        # TODO: The docstring contradicts (a) the type hint and (b) some invocations of this method
-        #       within this library, itself (they pass it a dictionary instead of a list).
-        #
-        # TODO: Add doctests demonstrating how this would treat an input list containing dictionaries
-        #       whose values contain single quotes (not as delimiters); e.g. { lastName: "O'Connor" }.
-        #       In general, consider using a standard serialization pipeline (e.g. dict -> json -> str)
-        #       instead of an ad hoc one so corner cases are covered.
-        #
-        return str(data).replace("'", '"')
 
     def convert_to_df(self, data: list[dict[str, Any]]) -> pd.DataFrame:
         """
@@ -200,10 +178,7 @@ class DataProcessing:
                 filter_dict[attribute_name] = {"$regex": escaped_value, "$options": "i"}
                 logging.debug(f"Filter dict: {filter_dict}")
 
-        # TODO: The value being passed to `_string_mongo_list` below might be a dictionary whose
-        #       values are string, and it might be a dictionary whose values are, themselves,
-        #       dictionaries. The method's docstring says it expects to be passed a LIST.
-        clean = self._string_mongo_list(filter_dict)
+        clean = json.dumps(filter_dict)
         logging.debug(f"Filter cleaned: {clean}")
         return clean
 


### PR DESCRIPTION
Use json.dumps() instead of `_string_mongo_list` method since it will take care of the quote conversion for filter building and will remove the issues with type consistency in the `_string_mongo_list` method