### PR TITLE
Standardize input params to requests

### DIFF
--- a/nmdc_api_utilities/api_client.py
+++ b/nmdc_api_utilities/api_client.py
@@ -137,14 +137,14 @@ class NMDCAPIClient(ABC):
                 content_type="application/json",
             )
 
-            # TODO: Consider using the `params` argument of `requests.get` to handle building the
-            #       URL's query string. That way, we would be delegating the responsibility of
-            #       encoding query parameters, to the `requests` library.
-            #       Reference: https://requests.readthedocs.io/en/latest/user/quickstart/#passing-parameters-in-urls
-            #
-            url = f"{url_prefix}?filter={filter}&max_page_size={max_page_size}&projection={fields}&page_token={next_page_token}"
+            params = {
+                "filter": filter,
+                "max_page_size": max_page_size,
+                "projection": fields,
+                "page_token": next_page_token,
+            }
             try:
-                response = requests.get(url, headers=headers)
+                response = requests.get(url_prefix, headers=headers, params=params)
                 response.raise_for_status()
             except requests.exceptions.RequestException as e:
                 logger.error("API request failed", exc_info=True)

--- a/nmdc_api_utilities/collection_search.py
+++ b/nmdc_api_utilities/collection_search.py
@@ -3,7 +3,6 @@
 import json
 import logging
 import re
-import urllib.parse
 from typing import Optional
 
 import requests
@@ -77,14 +76,16 @@ class CollectionSearch(NMDCSearch):
             If the API request fails.
 
         """
-        logging.debug(f"get_records Filter: {filter}")
-        filter = urllib.parse.quote(filter)
-        logging.debug(f"get_records encoded Filter: {filter}")
-        url_prefix = f"{self.api_base_url}/nmdcschema/{self.collection_name}"
-        url = f"{url_prefix}?filter={filter}&max_page_size={max_page_size}&projection={fields}"
+        url = f"{self.api_base_url}/nmdcschema/{self.collection_name}"
+        params = {
+            "filter": filter,
+            "max_page_size": max_page_size,
+            "projection": fields,
+        }
         try:
             response = requests.get(
-                url,
+                url=url,
+                params=params,
                 headers=self._build_http_request_headers(),
             )
             response.raise_for_status()
@@ -99,9 +100,9 @@ class CollectionSearch(NMDCSearch):
         results = response.json()["resources"]
         # otherwise, get all pages
         if all_pages:
-            results = self._get_all_pages(
-                response, url_prefix, filter, max_page_size, fields
-            )["resources"]
+            results = self._get_all_pages(response, url, filter, max_page_size, fields)[
+                "resources"
+            ]
 
         return results
 
@@ -237,12 +238,17 @@ class CollectionSearch(NMDCSearch):
             )
             record_id = collection_id
 
-        url = f"{self.api_base_url}/nmdcschema/{self.collection_name}/{record_id}?max_page_size={max_page_size}&projection={fields}"
+        url = f"{self.api_base_url}/nmdcschema/{self.collection_name}/{record_id}"
+        params = {
+            "max_page_size": max_page_size,
+            "projection": fields,
+        }
         # get the reponse
         try:
             response = requests.get(
-                url,
+                url=url,
                 headers=self._build_http_request_headers(),
+                params=params,
             )
             response.raise_for_status()
         except requests.exceptions.RequestException as e:


### PR DESCRIPTION
In some places we were not using the standard `params` parameter from the requests lib. Ensure each call to requests is using this format. 