### PR TITLE
Add query for biosamples within range of given location/biosample

### DIFF
--- a/docs/usage.ipynb
+++ b/docs/usage.ipynb
@@ -32,7 +32,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 11,
+      "execution_count": 1,
       "id": "9a63283cbaf04dbcab1f6479b197f3a8",
       "metadata": {
         "id": "ex1-step1",
@@ -84,7 +84,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 12,
+      "execution_count": 2,
       "id": "72eea5119410473aa328ad9291626812",
       "metadata": {
         "id": "ex1-step2-code",
@@ -135,7 +135,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 13,
+      "execution_count": 3,
       "id": "10185d26023b46108eb7d9f57d49d2b3",
       "metadata": {
         "id": "ex1-step3-code",
@@ -146,13 +146,13 @@
           "name": "stdout",
           "output_type": "stream",
           "text": [
-            "Data objects found: 382\n",
+            "Data objects found: 328\n",
             "\n",
             "Example data object \n",
-            "ID: nmdc:dobj-11-6v0wjh26\n",
-            "Name: nmdc_wfmtan-11-9jpgyv22.1_imgap.info\n",
-            "Description: Annotation info for nmdc:wfmtan-11-9jpgyv22.1\n",
-            "Link for downloading: https://data.microbiomedata.org/data/nmdc:dgns-11-hngnz807/nmdc:wfmtan-11-9jpgyv22.1/nmdc_wfmtan-11-9jpgyv22.1_imgap.info\n"
+            "ID: nmdc:dobj-11-9rde1580\n",
+            "Name: nmdc_wfmtan-11-8vvf5439.1_genemark.gff\n",
+            "Description: Genemark Annotations for nmdc:wfmtan-11-8vvf5439.1\n",
+            "Link for downloading: https://data.microbiomedata.org/data/nmdc:dgns-11-ghwwyc59/nmdc:wfmtan-11-8vvf5439.1/nmdc_wfmtan-11-8vvf5439.1_genemark.gff\n"
           ]
         }
       ],
@@ -193,7 +193,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 2,
+      "execution_count": 4,
       "id": "7623eae2785240b9bd12b16a66d81610",
       "metadata": {
         "id": "ex2-step1",
@@ -278,7 +278,7 @@
                   "type": "unknown"
                 }
               ],
-              "ref": "769493b0-89f7-48a4-9d21-43ee14641160",
+              "ref": "6be79dd0-faea-4078-b023-75ebb110f1c4",
               "rows": [
                 [
                   "0",
@@ -475,50 +475,17 @@
               "</div>"
             ],
             "text/plain": [
-              "                      id             type  \\\n",
-              "0  nmdc:dobj-11-00pns528  nmdc:DataObject   \n",
-              "1  nmdc:dobj-11-00xqnn30  nmdc:DataObject   \n",
-              "2  nmdc:dobj-11-00y67656  nmdc:DataObject   \n",
-              "3  nmdc:dobj-11-02dj2e39  nmdc:DataObject   \n",
-              "4  nmdc:dobj-11-02n14844  nmdc:DataObject   \n",
+              "                      id             type  ... alternative_identifiers  in_manifest\n",
+              "0  nmdc:dobj-11-00pns528  nmdc:DataObject  ...                     NaN          NaN\n",
+              "1  nmdc:dobj-11-00xqnn30  nmdc:DataObject  ...                     NaN          NaN\n",
+              "2  nmdc:dobj-11-00y67656  nmdc:DataObject  ...                     NaN          NaN\n",
+              "3  nmdc:dobj-11-02dj2e39  nmdc:DataObject  ...                     NaN          NaN\n",
+              "4  nmdc:dobj-11-02n14844  nmdc:DataObject  ...                     NaN          NaN\n",
               "\n",
-              "                                        name  file_size_bytes  \\\n",
-              "0  52441.2.335479.CACGTTGT-ACAACGTG.fastq.gz     1.002897e+10   \n",
-              "1  12844.2.289969.GTTCAACC-GGTTGAAC.fastq.gz     8.449439e+09   \n",
-              "2  52437.1.333590.GAACGCTT-AAGCGTTC.fastq.gz     1.097406e+10   \n",
-              "3  52561.2.384837.AGTACCGT-CTAGACTG.fastq.gz     8.848502e+09   \n",
-              "4  52437.3.333700.ACCTCTGT-ACAGAGGT.fastq.gz     1.100929e+10   \n",
-              "\n",
-              "                       md5_checksum      data_object_type  \\\n",
-              "0  0c70f5574024426432ea03eb3f130e01  Metagenome Raw Reads   \n",
-              "1  c8b53dad43beabb80d768f81ec1f0f9b  Metagenome Raw Reads   \n",
-              "2  d56df876ceb5006d0d0546c8e67500ee  Metagenome Raw Reads   \n",
-              "3  9dd6311f11abe3a960796d2c227d9d19  Metagenome Raw Reads   \n",
-              "4  1978fc04e0ce845651f0bdd4e0be1eb3  Metagenome Raw Reads   \n",
-              "\n",
-              "         was_generated_by                                                url  \\\n",
-              "0  nmdc:omprc-11-rdvzce03  https://data.microbiomedata.org/data/nmdc:ompr...   \n",
-              "1  nmdc:omprc-11-g8x3ed38  https://data.microbiomedata.org/data/nmdc:ompr...   \n",
-              "2  nmdc:omprc-11-3pn7ex35  https://data.microbiomedata.org/data/nmdc:ompr...   \n",
-              "3  nmdc:omprc-11-dsv4yv97  https://data.microbiomedata.org/data/nmdc:ompr...   \n",
-              "4  nmdc:omprc-11-0w5g0a55  https://data.microbiomedata.org/data/nmdc:ompr...   \n",
-              "\n",
-              "                                       description    data_category  \\\n",
-              "0  Metagenome Raw Reads for nmdc:omprc-11-rdvzce03  instrument_data   \n",
-              "1  Metagenome Raw Reads for nmdc:omprc-11-g8x3ed38  instrument_data   \n",
-              "2  Metagenome Raw Reads for nmdc:omprc-11-3pn7ex35  instrument_data   \n",
-              "3  Metagenome Raw Reads for nmdc:omprc-11-dsv4yv97  instrument_data   \n",
-              "4  Metagenome Raw Reads for nmdc:omprc-11-0w5g0a55  instrument_data   \n",
-              "\n",
-              "  alternative_identifiers in_manifest  \n",
-              "0                     NaN         NaN  \n",
-              "1                     NaN         NaN  \n",
-              "2                     NaN         NaN  \n",
-              "3                     NaN         NaN  \n",
-              "4                     NaN         NaN  "
+              "[5 rows x 12 columns]"
             ]
           },
-          "execution_count": 2,
+          "execution_count": 4,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -560,7 +527,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 15,
+      "execution_count": 5,
       "id": "b118ea5561624da68c537baed56e602f",
       "metadata": {
         "id": "ex2-step2-code",
@@ -616,7 +583,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 16,
+      "execution_count": 6,
       "id": "504fb2a444614c0babb325280ed9130a",
       "metadata": {
         "id": "ex2-step3-code",
@@ -654,6 +621,94 @@
         "\n",
         "print(f\"Biosamples fetched: {len(biosample_records)}\")\n",
         "print(f\"Objects with mapped biosamples: {len(biosamples_by_data_object)}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "6867dca8",
+      "metadata": {},
+      "source": [
+        "## Example 3: Study -> Biosamples -> ++ Biosamples\n",
+        "\n",
+        "**Goal:** Starting from a study of interest, increase the size of your database by searching for additional biosamples within a certain radius of those you've already found. \n",
+        "\n",
+        "### Step 1: Find biosamples from your study of interest"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 8,
+      "id": "3d7a9780",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Biosamples from original study: 104\n"
+          ]
+        }
+      ],
+      "source": [
+        "from nmdc_api_utilities import StudySearch\n",
+        "\n",
+        "study_client = StudySearch()\n",
+        "\n",
+        "study_id = \"nmdc:sty-11-8xdqsn54\"\n",
+        "\n",
+        "studies = study_client.get_record_by_attribute(\n",
+        "    attribute_name=\"id\",\n",
+        "    attribute_value=study_id,\n",
+        "    exact_match=True,\n",
+        ")\n",
+        "\n",
+        "biosamples = study_client.get_linked_instances(\n",
+        "    ids=[study_id],\n",
+        "    types=[\"nmdc:Biosample\"],\n",
+        "    hydrate=True,\n",
+        ")\n",
+        "biosample_ids = [record[\"id\"] for record in biosamples if \"id\" in record]\n",
+        "\n",
+        "print(f\"Biosamples from original study: {len(biosamples)}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "577df78a",
+      "metadata": {},
+      "source": [
+        "### Step 2: Find additional biosamples within a radius of the original biosamples"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 13,
+      "id": "7f81f627",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Additional biosamples found: 79\n"
+          ]
+        }
+      ],
+      "source": [
+        "from nmdc_api_utilities import BiosampleSearch\n",
+        "\n",
+        "biosample_client = BiosampleSearch()\n",
+        "\n",
+        "add_biosamples = []\n",
+        "for biosample_id in biosample_ids:\n",
+        "    new_biosamples = biosample_client.get_record_by_proximity(\n",
+        "        radius_meters=2000000,\n",
+        "        biosample_id=biosample_id,\n",
+        "    )\n",
+        "    for biosample in new_biosamples:\n",
+        "        if biosample[\"id\"] not in biosample_ids and biosample[\"id\"] not in [b[\"id\"] for b in add_biosamples]:\n",
+        "            add_biosamples.append(biosample)\n",
+        "print(f\"Additional biosamples found: {len(add_biosamples)}\")"
       ]
     },
     {

--- a/docs/usage.ipynb
+++ b/docs/usage.ipynb
@@ -32,7 +32,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 1,
+      "execution_count": 14,
       "id": "9a63283cbaf04dbcab1f6479b197f3a8",
       "metadata": {
         "id": "ex1-step1",
@@ -84,7 +84,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 2,
+      "execution_count": 15,
       "id": "72eea5119410473aa328ad9291626812",
       "metadata": {
         "id": "ex1-step2-code",
@@ -98,7 +98,7 @@
             "Biosamples found: 42\n",
             "Biosample IDs collected: 42\n",
             "Example biosample record: \n",
-            "{'id': 'nmdc:bsm-11-y52p4f86', 'type': 'nmdc:Biosample', '_downstream_of': ['nmdc:sty-11-8ws97026'], 'name': 'BW-H-4-O', 'associated_studies': ['nmdc:sty-11-8ws97026'], 'env_broad_scale': {'type': 'nmdc:ControlledIdentifiedTermValue', 'has_raw_value': 'forest biome [ENVO:01000174]', 'term': {'id': 'ENVO:01000174', 'type': 'nmdc:OntologyClass', 'name': 'forest biome'}}, 'env_local_scale': {'type': 'nmdc:ControlledIdentifiedTermValue', 'has_raw_value': 'organic horizon [ENVO:03600018]', 'term': {'id': 'ENVO:03600018', 'type': 'nmdc:OntologyClass', 'name': 'organic horizon'}}, 'env_medium': {'type': 'nmdc:ControlledIdentifiedTermValue', 'has_raw_value': 'heat stressed soil [ENVO:00005781]', 'term': {'id': 'ENVO:00005781', 'type': 'nmdc:OntologyClass', 'name': 'heat stressed soil'}}, 'samp_name': 'BW-H-4-O', 'collection_date': {'type': 'nmdc:TimestampValue', 'has_raw_value': '2017-05-24'}, 'depth': {'type': 'nmdc:QuantityValue', 'has_raw_value': '0 - .02', 'has_maximum_numeric_value': 0.02, 'has_minimum_numeric_value': 0.0, 'has_unit': 'm'}, 'ecosystem': 'Environmental', 'ecosystem_category': 'Terrestrial', 'ecosystem_subtype': 'Temperate forest', 'ecosystem_type': 'Soil', 'elev': 302.0, 'env_package': {'type': 'nmdc:TextValue', 'has_raw_value': 'soil'}, 'experimental_factor': {'type': 'nmdc:ControlledTermValue', 'has_raw_value': 'heat stress treatment [MCO:0000172]', 'term': {'id': 'MCO:0000172', 'type': 'nmdc:OntologyClass', 'name': 'heat stress treatment'}}, 'geo_loc_name': {'type': 'nmdc:TextValue', 'has_raw_value': 'USA: Massachusetts, Petersham'}, 'growth_facil': {'type': 'nmdc:ControlledTermValue', 'has_raw_value': 'field_incubation'}, 'lat_lon': {'type': 'nmdc:GeolocationValue', 'has_raw_value': '42.481016 -72.178343', 'latitude': 42.481016, 'longitude': -72.178343}, 'samp_store_temp': {'type': 'nmdc:QuantityValue', 'has_raw_value': '-80 Celsius', 'has_numeric_value': -80.0, 'has_unit': 'Cel'}, 'specific_ecosystem': 'O horizon/Organic', 'store_cond': {'type': 'nmdc:TextValue', 'has_raw_value': 'frozen'}, 'analysis_type': ['metagenomics', 'metatranscriptomics', 'lipidomics'], 'gold_biosample_identifiers': ['gold:Gb0158507']}\n"
+            "{'id': 'nmdc:bsm-11-xxvfda22', 'type': 'nmdc:Biosample', '_downstream_of': ['nmdc:sty-11-8ws97026'], 'name': 'BW-H-2-M', 'associated_studies': ['nmdc:sty-11-8ws97026'], 'env_broad_scale': {'type': 'nmdc:ControlledIdentifiedTermValue', 'has_raw_value': 'forest biome [ENVO:01000174]', 'term': {'id': 'ENVO:01000174', 'type': 'nmdc:OntologyClass', 'name': 'forest biome'}}, 'env_local_scale': {'type': 'nmdc:ControlledIdentifiedTermValue', 'has_raw_value': 'mineral horizon [ENVO:03600011]', 'term': {'id': 'ENVO:03600011', 'type': 'nmdc:OntologyClass', 'name': 'mineral horizon'}}, 'env_medium': {'type': 'nmdc:ControlledIdentifiedTermValue', 'has_raw_value': 'heat stressed soil [ENVO:00005781]', 'term': {'id': 'ENVO:00005781', 'type': 'nmdc:OntologyClass', 'name': 'heat stressed soil'}}, 'samp_name': 'BW-H-2-M', 'collection_date': {'type': 'nmdc:TimestampValue', 'has_raw_value': '2017-05-24'}, 'depth': {'type': 'nmdc:QuantityValue', 'has_raw_value': '.02 -.10', 'has_maximum_numeric_value': 0.1, 'has_minimum_numeric_value': 0.02, 'has_unit': 'm'}, 'ecosystem': 'Environmental', 'ecosystem_category': 'Terrestrial', 'ecosystem_subtype': 'Temperate forest', 'ecosystem_type': 'Soil', 'elev': 302.0, 'env_package': {'type': 'nmdc:TextValue', 'has_raw_value': 'soil'}, 'experimental_factor': {'type': 'nmdc:ControlledTermValue', 'has_raw_value': 'heat stress treatment [MCO:0000172]', 'term': {'id': 'MCO:0000172', 'type': 'nmdc:OntologyClass', 'name': 'heat stress treatment'}}, 'geo_loc_name': {'type': 'nmdc:TextValue', 'has_raw_value': 'USA: Massachusetts, Petersham'}, 'growth_facil': {'type': 'nmdc:ControlledTermValue', 'has_raw_value': 'field_incubation'}, 'lat_lon': {'type': 'nmdc:GeolocationValue', 'has_raw_value': '42.481016 -72.178343', 'latitude': 42.481016, 'longitude': -72.178343}, 'samp_store_temp': {'type': 'nmdc:QuantityValue', 'has_raw_value': '-80 Celsius', 'has_numeric_value': -80.0, 'has_unit': 'Cel'}, 'specific_ecosystem': 'Mineral soil', 'store_cond': {'type': 'nmdc:TextValue', 'has_raw_value': 'frozen'}, 'analysis_type': ['metatranscriptomics', 'metagenomics', 'natural organic matter', 'metaproteomics', 'metabolomics', 'lipidomics'], 'gold_biosample_identifiers': ['gold:Gb0157175', 'gold:Gb0158483']}\n"
           ]
         }
       ],
@@ -135,7 +135,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 3,
+      "execution_count": 16,
       "id": "10185d26023b46108eb7d9f57d49d2b3",
       "metadata": {
         "id": "ex1-step3-code",
@@ -146,13 +146,13 @@
           "name": "stdout",
           "output_type": "stream",
           "text": [
-            "Data objects found: 328\n",
+            "Data objects found: 440\n",
             "\n",
             "Example data object \n",
-            "ID: nmdc:dobj-11-9rde1580\n",
-            "Name: nmdc_wfmtan-11-8vvf5439.1_genemark.gff\n",
-            "Description: Genemark Annotations for nmdc:wfmtan-11-8vvf5439.1\n",
-            "Link for downloading: https://data.microbiomedata.org/data/nmdc:dgns-11-ghwwyc59/nmdc:wfmtan-11-8vvf5439.1/nmdc_wfmtan-11-8vvf5439.1_genemark.gff\n"
+            "ID: nmdc:dobj-11-hqw0bt67\n",
+            "Name: nmdc_wfmtan-11-8vvf5439.1_supfam.gff\n",
+            "Description: SUPERFam Annotations for nmdc:wfmtan-11-8vvf5439.1\n",
+            "Link for downloading: https://data.microbiomedata.org/data/nmdc:dgns-11-ghwwyc59/nmdc:wfmtan-11-8vvf5439.1/nmdc_wfmtan-11-8vvf5439.1_supfam.gff\n"
           ]
         }
       ],
@@ -193,7 +193,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 4,
+      "execution_count": 17,
       "id": "7623eae2785240b9bd12b16a66d81610",
       "metadata": {
         "id": "ex2-step1",
@@ -278,7 +278,7 @@
                   "type": "unknown"
                 }
               ],
-              "ref": "6be79dd0-faea-4078-b023-75ebb110f1c4",
+              "ref": "75c5cf79-04e8-4bf6-938e-34e4294eae3b",
               "rows": [
                 [
                   "0",
@@ -485,7 +485,7 @@
               "[5 rows x 12 columns]"
             ]
           },
-          "execution_count": 4,
+          "execution_count": 17,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -527,7 +527,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 5,
+      "execution_count": 18,
       "id": "b118ea5561624da68c537baed56e602f",
       "metadata": {
         "id": "ex2-step2-code",
@@ -583,7 +583,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 6,
+      "execution_count": 19,
       "id": "504fb2a444614c0babb325280ed9130a",
       "metadata": {
         "id": "ex2-step3-code",
@@ -637,7 +637,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 8,
+      "execution_count": 20,
       "id": "3d7a9780",
       "metadata": {},
       "outputs": [
@@ -682,15 +682,19 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 13,
+      "execution_count": 21,
       "id": "7f81f627",
       "metadata": {},
       "outputs": [
         {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Additional biosamples found: 79\n"
+          "ename": "TypeError",
+          "evalue": "LatLongFilters.get_record_by_proximity() got an unexpected keyword argument 'radius_km'",
+          "output_type": "error",
+          "traceback": [
+            "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+            "\u001b[31mTypeError\u001b[39m                                 Traceback (most recent call last)",
+            "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[21]\u001b[39m\u001b[32m, line 7\u001b[39m\n\u001b[32m      3\u001b[39m biosample_client = BiosampleSearch()\n\u001b[32m      4\u001b[39m \n\u001b[32m      5\u001b[39m add_biosamples = []\n\u001b[32m      6\u001b[39m \u001b[38;5;28;01mfor\u001b[39;00m biosample_id \u001b[38;5;28;01min\u001b[39;00m biosample_ids:\n\u001b[32m----> \u001b[39m\u001b[32m7\u001b[39m     new_biosamples = biosample_client.get_record_by_proximity(\n\u001b[32m      8\u001b[39m         radius_km=\u001b[32m2000\u001b[39m,\n\u001b[32m      9\u001b[39m         record_id=biosample_id,\n\u001b[32m     10\u001b[39m     )\n",
+            "\u001b[31mTypeError\u001b[39m: LatLongFilters.get_record_by_proximity() got an unexpected keyword argument 'radius_km'"
           ]
         }
       ],
@@ -702,8 +706,8 @@
         "add_biosamples = []\n",
         "for biosample_id in biosample_ids:\n",
         "    new_biosamples = biosample_client.get_record_by_proximity(\n",
-        "        radius_meters=2000000,\n",
-        "        biosample_id=biosample_id,\n",
+        "        radius_km=2000,\n",
+        "        record_id=biosample_id,\n",
         "    )\n",
         "    for biosample in new_biosamples:\n",
         "        if biosample[\"id\"] not in biosample_ids and biosample[\"id\"] not in [b[\"id\"] for b in add_biosamples]:\n",

--- a/nmdc_api_utilities/lat_long_filters.py
+++ b/nmdc_api_utilities/lat_long_filters.py
@@ -265,8 +265,8 @@ class LatLongFilters(ABC):
 
     def get_record_by_proximity(
         self,
-        radius_meters: float,
-        biosample_id: str | None = None,
+        radius_km: float,
+        record_id: str | None = None,
         query_lat: float | None = None,
         query_lon: float | None = None,
         page_size: int = 25,
@@ -274,19 +274,21 @@ class LatLongFilters(ABC):
         all_pages: bool = False,
     ) -> list[dict]:
         """
-        Retrieve records by proximity to a biosample or lat lon via the NMDC API.
+        Retrieve records by proximity to a record or lat lon via the NMDC API.
         First retrieve records within a bounding box, then refine to those within the circular radius.
 
         Parameters
         ----------
-        radius_meters
-            The radius in meters to search for records around the biosample.
-        biosample_id
-            The ID of the biosample to query. If provided, query_lat and query_lon must not be provided.
+        radius_km
+            The radius in kilometers to search for records around the record.
+        record_id
+            The ID of a record to query where lat/lon are provided (Biosample or FieldResearchSite). If provided, query_lat and query_lon must not be provided.
         query_lat
-            The latitude to query. If provided, biosample_id must not be provided.
+            The latitude, in decimal degrees, to query. If provided, record_id must not be provided.
+            Example: "63.875088"
         query_lon
-            The longitude to query. If provided, biosample_id must not be provided.
+            The longitude, in decimal degrees, to query. If provided, record_id must not be provided.
+            Example: "-149.210438"
         page_size
             The number of results to return per page.
         fields
@@ -301,14 +303,14 @@ class LatLongFilters(ABC):
             A list of records.
 
         """
-        if biosample_id is not None and (
-            query_lat is not None or query_lon is not None
-        ):
+        radius_meters = radius_km * 1000
+
+        if record_id is not None and (query_lat is not None or query_lon is not None):
             logger.error(
-                "Invalid input: ONLY biosample_id or query_lat/query_lon can be used, not both."
+                "Invalid input: ONLY record_id or query_lat/query_lon can be used, not both."
             )
             raise ValueError(
-                "Invalid input: ONLY biosample_id or query_lat/query_lon can be used, not both."
+                "Invalid input: ONLY record_id or query_lat/query_lon can be used, not both."
             )
         if (
             query_lat is not None
@@ -324,16 +326,16 @@ class LatLongFilters(ABC):
             )
 
         # Calculate bounding box for mongoDB query
-        if biosample_id is not None:
-            biosample_lat_lon = self.get_records(
-                filter=f'{{"id": "{biosample_id}"}}',
+        if record_id is not None:
+            record_lat_lon = self.get_records(
+                filter=f'{{"id": "{record_id}"}}',
                 max_page_size=1,
                 fields="lat_lon",
                 all_pages=False,
                 shape="records",
             )
-            center_lat = biosample_lat_lon[0].get("lat_lon", {}).get("latitude")
-            center_lon = biosample_lat_lon[0].get("lat_lon", {}).get("longitude")
+            center_lat = record_lat_lon[0].get("lat_lon", {}).get("latitude")
+            center_lon = record_lat_lon[0].get("lat_lon", {}).get("longitude")
         if query_lat is not None and query_lon is not None:
             center_lat = query_lat
             center_lon = query_lon

--- a/nmdc_api_utilities/lat_long_filters.py
+++ b/nmdc_api_utilities/lat_long_filters.py
@@ -285,10 +285,10 @@ class LatLongFilters(ABC):
             The ID of a record to query where lat/lon are provided (Biosample or FieldResearchSite). If provided, query_lat and query_lon must not be provided.
         query_lat
             The latitude, in decimal degrees, to query. If provided, record_id must not be provided.
-            Example: "63.875088"
+            Example: 63.875088
         query_lon
             The longitude, in decimal degrees, to query. If provided, record_id must not be provided.
-            Example: "-149.210438"
+            Example: -149.210438
         page_size
             The number of results to return per page.
         fields

--- a/nmdc_api_utilities/lat_long_filters.py
+++ b/nmdc_api_utilities/lat_long_filters.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import logging
+import math
 from abc import ABC, abstractmethod
 from typing import Literal, cast
 
@@ -213,3 +214,153 @@ class LatLongFilters(ABC):
             filter, page_size, fields, all_pages, shape="records"
         )
         return cast(list[dict], results)
+
+    @staticmethod
+    def _bounding_box(center_lat: float, center_lon: float, radius_m: float):
+        """
+        Compute (min_lat, max_lat, min_lon, max_lon) for a circle of radius_m (meters)
+        around (center_lat, center_lon). Good approximation for typical radii.
+        """
+        R = 6378137.0  # Earth radius in meters (WGS84)
+        lat_rad = math.radians(center_lat)
+
+        # Angular distance in radians on Earth’s surface
+        ang_dist = radius_m / R
+
+        # Latitude bounds
+        min_lat = center_lat - math.degrees(ang_dist)
+        max_lat = center_lat + math.degrees(ang_dist)
+
+        # Longitude bounds
+        if abs(lat_rad) > (math.pi / 2 - 1e-6):
+            # Near the poles: longitude is essentially all longitudes
+            min_lon = -180.0
+            max_lon = 180.0
+        else:
+            delta_lon = math.asin(math.sin(ang_dist) / math.cos(lat_rad))
+            min_lon = center_lon - math.degrees(delta_lon)
+            max_lon = center_lon + math.degrees(delta_lon)
+
+        return min_lat, max_lat, min_lon, max_lon
+
+    @staticmethod
+    def _haversine_distance_m(
+        lat1: float, lon1: float, lat2: float, lon2: float
+    ) -> float:
+        """
+        Great-circle distance in meters between two points on Earth.
+        """
+        R = 6378137.0  # Earth radius in meters
+        phi1 = math.radians(lat1)
+        phi2 = math.radians(lat2)
+        dphi = math.radians(lat2 - lat1)
+        dlambda = math.radians(lon2 - lon1)
+
+        a = (
+            math.sin(dphi / 2.0) ** 2
+            + math.cos(phi1) * math.cos(phi2) * math.sin(dlambda / 2.0) ** 2
+        )
+        c = 2 * math.atan2(math.sqrt(a), math.sqrt(1.0 - a))
+        return R * c
+
+    def get_record_by_proximity(
+        self,
+        radius_meters: float,
+        biosample_id: str | None = None,
+        query_lat: float | None = None,
+        query_lon: float | None = None,
+        page_size: int = 25,
+        fields: str = "",
+        all_pages: bool = False,
+    ) -> list[dict]:
+        """
+        Retrieve records by proximity to a biosample or lat lon via the NMDC API.
+        First retrieve records within a bounding box, then refine to those within the circular radius.
+
+        Parameters
+        ----------
+        radius_meters
+            The radius in meters to search for records around the biosample.
+        biosample_id
+            The ID of the biosample to query. If provided, query_lat and query_lon must not be provided.
+        query_lat
+            The latitude to query. If provided, biosample_id must not be provided.
+        query_lon
+            The longitude to query. If provided, biosample_id must not be provided.
+        page_size
+            The number of results to return per page.
+        fields
+            The fields to return. If empty, all fields are returned.
+            Example: "id,name,description,type"
+        all_pages
+            True to return all pages. False to return the first page.
+
+        Returns
+        -------
+        list[dict]
+            A list of records.
+
+        """
+        if biosample_id is not None and (
+            query_lat is not None or query_lon is not None
+        ):
+            logger.error(
+                "Invalid input: ONLY biosample_id or query_lat/query_lon can be used, not both."
+            )
+            raise ValueError(
+                "Invalid input: ONLY biosample_id or query_lat/query_lon can be used, not both."
+            )
+        if (
+            query_lat is not None
+            and query_lon is None
+            or query_lat is None
+            and query_lon is not None
+        ):
+            logger.error(
+                "Invalid input: BOTH query_lat and query_lon must be provided."
+            )
+            raise ValueError(
+                "Invalid input: BOTH query_lat and query_lon must be provided."
+            )
+
+        # Calculate bounding box for mongoDB query
+        if biosample_id is not None:
+            biosample_lat_lon = self.get_records(
+                filter=f'{{"id": "{biosample_id}"}}',
+                max_page_size=1,
+                fields="lat_lon",
+                all_pages=False,
+                shape="records",
+            )
+            center_lat = biosample_lat_lon[0].get("lat_lon", {}).get("latitude")
+            center_lon = biosample_lat_lon[0].get("lat_lon", {}).get("longitude")
+        if query_lat is not None and query_lon is not None:
+            center_lat = query_lat
+            center_lon = query_lon
+        min_lat, max_lat, min_lon, max_lon = self._bounding_box(
+            center_lat, center_lon, radius_meters
+        )
+
+        # MongoDB query with bounding box
+        filter = f'{{"lat_lon.latitude": {{"$gte": {min_lat}, "$lte": {max_lat}}},"lat_lon.longitude": {{"$gte": {min_lon}, "$lte": {max_lon}}}}}'
+        results = cast(
+            list[dict],
+            self.get_records(filter, page_size, fields, all_pages, shape="records"),
+        )
+
+        # Refine results to those within circular radius
+        refined_results = []
+        for record in results:
+            lat_lon = record.get("lat_lon")
+            if not isinstance(lat_lon, dict):
+                continue
+            rec_lat = lat_lon.get("latitude")
+            rec_lon = lat_lon.get("longitude")
+            if rec_lat is not None and rec_lon is not None:
+                distance = self._haversine_distance_m(
+                    center_lat, center_lon, rec_lat, rec_lon
+                )
+                if distance <= radius_meters:
+                    refined_results.append(record)
+
+        return cast(list[dict], refined_results)

--- a/nmdc_api_utilities/test/test_biosample.py
+++ b/nmdc_api_utilities/test/test_biosample.py
@@ -65,24 +65,24 @@ def test_biosample_by_proximity_biosample():
     results = biosample.get_record_by_proximity(
         radius_meters=1000, biosample_id="nmdc:bsm-11-7bk7nf04"
     )
-    assert len(results) > 0
+    assert len(results) > 5
 
 
 def test_biosample_by_proximity_location():
     biosample = BiosampleSearch(api_base_url=API_BASE_URL)
     results = biosample.get_record_by_proximity(
-        radius_meters=100000,
-        query_lat=37.851667,
-        query_lon=-122.294444,
+        radius_meters=2180000,
+        query_lat=65.42577,
+        query_lon=-150.416496,
         all_pages=True,
     )
-    assert len(results) > 0
+    assert len(results) > 1000
     captured_studies = {
         study_id
         for result in results
         for study_id in result.get("associated_studies", [])
     }
-    assert len(captured_studies) > 1
+    assert len(captured_studies) > 10
 
 
 def test_biosample_build_filter_1():

--- a/nmdc_api_utilities/test/test_biosample.py
+++ b/nmdc_api_utilities/test/test_biosample.py
@@ -63,7 +63,7 @@ def test_biosample_by_lat_long():
 def test_biosample_by_proximity_biosample():
     biosample = BiosampleSearch(api_base_url=API_BASE_URL)
     results = biosample.get_record_by_proximity(
-        radius_meters=1000, biosample_id="nmdc:bsm-11-7bk7nf04"
+        radius_km=1, record_id="nmdc:bsm-11-7bk7nf04"
     )
     assert len(results) > 5
 
@@ -71,7 +71,7 @@ def test_biosample_by_proximity_biosample():
 def test_biosample_by_proximity_location():
     biosample = BiosampleSearch(api_base_url=API_BASE_URL)
     results = biosample.get_record_by_proximity(
-        radius_meters=2180000,
+        radius_km=2180,
         query_lat=65.42577,
         query_lon=-150.416496,
         all_pages=True,

--- a/nmdc_api_utilities/test/test_biosample.py
+++ b/nmdc_api_utilities/test/test_biosample.py
@@ -60,6 +60,31 @@ def test_biosample_by_lat_long():
     assert results[0]["lat_lon"]["longitude"] == -149.210438
 
 
+def test_biosample_by_proximity_biosample():
+    biosample = BiosampleSearch(api_base_url=API_BASE_URL)
+    results = biosample.get_record_by_proximity(
+        radius_meters=1000, biosample_id="nmdc:bsm-11-7bk7nf04"
+    )
+    assert len(results) > 0
+
+
+def test_biosample_by_proximity_location():
+    biosample = BiosampleSearch(api_base_url=API_BASE_URL)
+    results = biosample.get_record_by_proximity(
+        radius_meters=100000,
+        query_lat=37.851667,
+        query_lon=-122.294444,
+        all_pages=True,
+    )
+    assert len(results) > 0
+    captured_studies = {
+        study_id
+        for result in results
+        for study_id in result.get("associated_studies", [])
+    }
+    assert len(captured_studies) > 1
+
+
 def test_biosample_build_filter_1():
     u = DataProcessing()
     b = BiosampleSearch(api_base_url=API_BASE_URL)


### PR DESCRIPTION
Added functionality to allow a user to search for biosamples within a certain radius of either a target location (provided as lat/long) or a target biosample. 
Added test to assure that more than 5 biosamples returned when searching within 1000m of `nmdc:bsm-11-7bk7nf04` (near Blacksburg, Virginia)
Added test to assure that more than 1000 biosamples from more than 10 studies return when searching within 2180000m of 65.42577 lat and -150.416496 long (near center of Alaska)