### PR TITLE
Upgrade and pin third-party actions using commit hashes

### DIFF
--- a/.github/workflows/dev_tests.yml
+++ b/.github/workflows/dev_tests.yml
@@ -25,8 +25,8 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v6  # docs: https://github.com/marketplace/actions/checkout
-      - uses: astral-sh/setup-uv@v6  # docs: https://github.com/marketplace/actions/astral-sh-setup-uv
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
@@ -41,7 +41,7 @@ jobs:
         run: uv run pytest -x nmdc_api_utilities/
       - name: Create Issue
         if: failure() && github.event.pull_request == null && github.event_name == 'schedule'
-        uses: actions/github-script@v6
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -13,8 +13,8 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6  # docs: https://github.com/marketplace/actions/checkout
-      - uses: astral-sh/setup-uv@v6  # docs: https://github.com/marketplace/actions/astral-sh-setup-uv
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           enable-cache: true
       - name: Install Python dependencies
@@ -22,7 +22,7 @@ jobs:
       - name: Sphinx build
         run: uv run sphinx-build -v docs build/html
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         with:
           publish_branch: gh-pages

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -19,12 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v6  # docs: https://github.com/marketplace/actions/checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v6  # docs: https://github.com/marketplace/actions/astral-sh-setup-uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           enable-cache: true
 

--- a/.github/workflows/prod_tests.yml
+++ b/.github/workflows/prod_tests.yml
@@ -25,8 +25,8 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v6  # docs: https://github.com/marketplace/actions/checkout
-      - uses: astral-sh/setup-uv@v6  # docs: https://github.com/marketplace/actions/astral-sh-setup-uv
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
@@ -41,7 +41,7 @@ jobs:
         run: uv run pytest -x nmdc_api_utilities/
       - name: Create Issue
         if: failure() && github.event.pull_request == null && github.event_name == 'schedule'
-        uses: actions/github-script@v6
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out commit  # Docs: https://github.com/actions/checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
@@ -37,7 +37,7 @@ jobs:
       - name: Build package  # Docs: https://docs.astral.sh/uv/reference/cli/#uv-build
         run: uv build
       - name: Save the built package for publishing later  # Docs: https://github.com/actions/upload-artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: built-package
           path: dist
@@ -61,11 +61,11 @@ jobs:
       id-token: write
     steps:
       - name: Load the built package for publishing  # Docs: https://github.com/actions/download-artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: built-package
           path: dist
       - name: List contents of `dist` directory
         run: ls -lh dist
       - name: Publish package to PyPI  # Docs: https://github.com/pypa/gh-action-pypi-publish
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0


### PR DESCRIPTION
These changes implement the recommend security hardening step of [pinning third party actions](https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions) using commit hashes. They also do an upgrade to avoid using [deprecated Node 20 actions](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).

---

Implementation note: these changes were automatically generated with [pinact](https://github.com/suzuki-shunsuke/pinact):
```
pinact run --update --min-age 7
```