### PR TITLE
Update `has_deprecated_parameter` decorator to normalize docstring indentation before injecting note

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -19,10 +19,13 @@ jobs:
           enable-cache: true
       - name: Install Python dependencies
         run: uv sync --locked --group docs
-      - name: (Debug) Dump environment variables
-        run: printenv
-      - name: (Debug) Dump Python package versions
-        run: uv pip freeze
+      - name: (Debug) Dump debug info
+        run: |
+          echo "VIRTUAL_ENV    : ${VIRTUAL_ENV}"
+          echo "CONDA_PREFIX   : ${CONDA_PREFIX}"
+          echo "Python path    : $(uv python find)"
+          echo "Python version : $(uv run python --version)"
+          echo "Python package versions:\n$(uv pip freeze)"
       # Reference: https://www.sphinx-doc.org/en/master/man/sphinx-build.html
       - name: Build Sphinx documentation
         run: uv run sphinx-build --fresh-env -v docs build/html

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -19,16 +19,15 @@ jobs:
           enable-cache: true
       - name: Install Python dependencies
         run: uv sync --locked --group docs
-      - name: (Debug) Dump debug info
+      - name: (Debug) Dump environment details
         run: |
           echo "VIRTUAL_ENV    : ${VIRTUAL_ENV}"
           echo "CONDA_PREFIX   : ${CONDA_PREFIX}"
           echo "Python path    : $(uv python find)"
           echo "Python version : $(uv run python --version)"
           echo "Python package versions:\n$(uv pip freeze)"
-      # Reference: https://www.sphinx-doc.org/en/master/man/sphinx-build.html
-      - name: Build Sphinx documentation
-        run: uv run sphinx-build --fresh-env -v docs build/html
+      - name: Sphinx build
+        run: uv run sphinx-build -v docs build/html
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -19,6 +19,10 @@ jobs:
           enable-cache: true
       - name: Install Python dependencies
         run: uv sync --locked --group docs
+      - name: (Debug) Dump environment variables
+        run: printenv
+      - name: (Debug) Dump Python package versions
+        run: uv pip freeze
       - name: Sphinx build
         run: uv run sphinx-build -v docs build/html
       - name: Deploy to GitHub Pages

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -23,8 +23,9 @@ jobs:
         run: printenv
       - name: (Debug) Dump Python package versions
         run: uv pip freeze
-      - name: Sphinx build
-        run: uv run sphinx-build -v docs build/html
+      # Reference: https://www.sphinx-doc.org/en/master/man/sphinx-build.html
+      - name: Build Sphinx documentation
+        run: uv run sphinx-build --fresh-env -v docs build/html
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -25,7 +25,8 @@ jobs:
           echo "CONDA_PREFIX   : ${CONDA_PREFIX}"
           echo "Python path    : $(uv python find)"
           echo "Python version : $(uv run python --version)"
-          echo "Python package versions:\n$(uv pip freeze)"
+          echo "Python package versions:"
+          uv pip freeze
       - name: Sphinx build
         run: uv run sphinx-build -v docs build/html
       - name: Deploy to GitHub Pages

--- a/nmdc_api_utilities/decorators.py
+++ b/nmdc_api_utilities/decorators.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from functools import wraps
+from inspect import getdoc
 
 from deprecated.params import deprecated_params
 
@@ -115,7 +116,13 @@ def has_deprecated_parameter(
         sphinx_note = "\n".join(sphinx_note_lines)
 
         # Augment the decorated function's or class's docstring with the Sphinx note.
-        original_docstring = decorated_class_or_func.__doc__
+        #
+        # Note: We use `inspect.getdoc(x)` instead of `x.__doc__` because, unlike the latter, the
+        #       former normalizes the indentation level of the docstring lines. This way, we don't
+        #       have to indent our injected note to different levels for different docstrings.
+        #       Reference: https://docs.python.org/3/library/inspect.html#inspect.getdoc
+        #
+        original_docstring = getdoc(decorated_class_or_func)
         if not isinstance(original_docstring, str):
             original_docstring = ""
         decorated_class_or_func.__doc__ = (


### PR DESCRIPTION
On this branch, I did two things:
1. **I fixed an indentation-related bug in the `has_deprecated_parameter` decorator.**
   1. The bug was that the admonition was being injected at the same indentation level, regardless of the indentation level of the existing docstring content. This was throwing off Sphinx in the GHA workflow. I had not noticed it during development, because I had been developing with Python 3.13; and Python 3.13 happens to have introduced "[automatic trimming of leading whitespace of docstrings](https://docs.python.org/3/whatsnew/3.13.html)". That's why the bug was only coming into play with older Python versions. Indeed, the GHA workflow is using Python 3.12, not Python 3.13, which explains to me why the behavior was different in the two contexts.
   2. The bugfix I applied was to change the way the decorator gets the original docstring. Previously, it was getting the "raw" docstring. Now, it gets a indentation-normalized version of the docstring.
2. **I added commands to the GHA workflow that I found useful for identifying the root cause of this symptom.**
   1. I am opting to leave them in there to aid in future debug.

Fixes #221 