### PR TITLE
Update the version the docs display & deployment trigger

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -27,6 +27,9 @@ jobs:
           echo "Python package versions:"
           uv pip freeze
       - name: Sphinx build
+        # References:
+        # - https://www.sphinx-doc.org/en/master/man/sphinx-build.html#cmdoption-sphinx-build-D (RE: `-D`)
+        # - https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-release (RE: `release`)
         run: |
           SHORT_HASH=$(git rev-parse --short HEAD)
           REF_NAME="${{ github.ref_name }}"

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,9 +1,8 @@
 name: documentation
 
 on:
-  push:
-    branches: [ main ]
-  pull_request:
+  release:
+    types: [ published ]
   workflow_dispatch:
 
 permissions:
@@ -28,10 +27,14 @@ jobs:
           echo "Python package versions:"
           uv pip freeze
       - name: Sphinx build
-        run: uv run sphinx-build -v docs build/html
+        run: |
+          SHORT_HASH=$(git rev-parse --short HEAD)
+          REF_NAME="${{ github.ref_name }}"
+          uv run sphinx-build -v docs build/html \
+            -D "release=${REF_NAME}+${SHORT_HASH}"
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        if: ${{ github.event_name == 'release' }}
         with:
           publish_branch: gh-pages
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR changes the documentation build&deployment to be triggered in GH release. It also overrides the sphinx build version to use the shorthand commit hash as well as the github ref name which will be the new release version. 

I tested this locally with success. 

<img width="493" height="199" alt="Screenshot 2026-06-09 at 11 58 45 AM" src="https://github.com/user-attachments/assets/1db4fd8d-5056-4b17-ab7a-dce291f0f20b" />
