### PR TITLE
Fix PyPI publish: pass secrets to the reusable prod-tests workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,11 @@ jobs:
   prod_tests:
     name: Check format and run tests
     uses: ./.github/workflows/prod_tests.yml
+    # Reusable workflows do NOT receive the caller's secrets by default, so
+    # without this the `CLIENT_ID` / `CLIENT_SECRET` used by the prod tests are
+    # empty and the authenticated `mint` test fails with AuthenticationError.
+    # Docs: https://docs.github.com/en/actions/using-workflows/reusing-workflows#passing-inputs-and-secrets-to-a-reusable-workflow
+    secrets: inherit
   build:
     name: Build package
     # This job depends upon other jobs succeeding.


### PR DESCRIPTION
## Problem

The release that publishes to PyPI ([run for `v1.0.1`](https://github.com/microbiomedata/nmdc-client/actions/runs/30037717595)) failed. The `publish` and `build` jobs never ran — they were skipped because the `prod_tests` job they depend on failed:

```
test_mint.py::test_mint_single —
nmdc_client.decorators.AuthenticationError: mint requires authentication.
Either provide `client_id` and `client_secret` OR `username` and `password`.
```

## Root cause

`publish.yml` runs the production tests via a **reusable workflow**:

```yaml
prod_tests:
  uses: ./.github/workflows/prod_tests.yml   # no secrets passed
```

Reusable workflows do **not** inherit the caller's secrets by default, so inside `prod_tests.yml` the expressions `${{ secrets.CLIENT_ID }}` / `${{ secrets.CLIENT_SECRET }}` evaluated to empty strings. The authenticated `mint` test then raised `AuthenticationError`, and pytest's `-x` aborted the job — skipping `build` and `publish`.

This is why the **same** `prod_tests.yml` passes when it runs directly (push / schedule / pull_request) but fails when invoked from `publish.yml`.

## Fix

Add `secrets: inherit` to the `prod_tests` job so the reusable workflow receives the caller's secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)